### PR TITLE
Add GitHub Actions release workflow and semantic-release config; update README badges

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,44 @@
+name: Release & Tagging
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Lint Conventional Commits
+        if: github.event_name == 'pull_request'
+        uses: wagoid/commitlint-github-action@v5
+
+      - name: Ensure initial tag v0.0.0
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if ! git rev-parse "v0.0.0" >/dev/null 2>&1; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git tag v0.0.0
+            git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }} v0.0.0
+          fi
+
+      - name: Semantic Release
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: cycjimmy/semantic-release-action@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,11 @@
+{
+  "branches": [
+    "main"
+  ],
+  "tagFormat": "v${version}",
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/github"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # smart-ide-services
 
-Backend for Smart IDE App
+[![Build](https://img.shields.io/github/actions/workflow/status/OWNER/REPO/ci.yaml?branch=main&label=build)](https://github.com/OWNER/REPO/actions/workflows/ci.yaml)
+[![Version](https://img.shields.io/github/v/release/OWNER/REPO?sort=semver)](https://github.com/OWNER/REPO/releases)
+[![License](https://img.shields.io/github/license/OWNER/REPO)](./LICENSE)
+
+> Replace `OWNER/REPO` in the badge URLs above with your GitHub repository slug (for example, `acme/smart-ide-services`).
+
+Backend for Smart IDE App.
+
+This project uses a GitHub Actions release pipeline (`.github/workflows/ci.yaml`) with Conventional Commit linting and semantic-release to automate tagging and release notes on pushes to `main`.
 
 ## Git commit hook (Conventional Commits)
 


### PR DESCRIPTION
### Motivation

- Automate release tagging and release notes generation on pushes to `main` using semantic-release. 
- Enforce Conventional Commit messages on PRs to drive semantic versioning.
- Surface CI and release metadata in the `README` via badges.

### Description

- Add a GitHub Actions workflow `.github/workflows/ci.yaml` that checks out code, lints PR commit messages with `wagoid/commitlint-github-action@v5`, ensures an initial `v0.0.0` tag exists, and runs `cycjimmy/semantic-release-action@v4` on pushes to `main`.
- Add a `.releaserc` file configuring `semantic-release` to use the `main` branch, `v${version}` tag format, and the `@semantic-release/commit-analyzer`, `@semantic-release/release-notes-generator`, and `@semantic-release/github` plugins.
- Update `README.md` to include build, version, and license badges and instructions to replace `OWNER/REPO` with the repository slug and a short description of the release pipeline.

### Testing

- No automated tests were executed as part of this PR; the new workflow will run `LINT Conventional Commits` on pull requests and `Semantic Release` on pushes to `main` once merged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef3ad6b27c832894cc8e45f76abc3d)