### PR TITLE
Add FastMCP backend service that proxies prompts to local Ollama

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,110 @@
 # smart-ide-services
-Backend for Smart IDE App
+
+Backend MCP service for Smart IDE App.
+
+## What this provides
+
+A runnable FastMCP server (following the official FastMCP quickstart pattern) with:
+
+- `send_prompt(prompt)` tool to receive user messages and route them to local Ollama.
+- `health_check()` tool to verify local Ollama availability and model readiness.
+- `chat_prompt(user_message)` MCP prompt template.
+- Default model set to `qwen2.5vl:7b`.
+
+## Prerequisites
+
+- Python 3.10+
+- Ollama installed and running locally
+- Model pulled locally:
+
+```bash
+ollama pull qwen2.5vl:7b
+```
+
+## Install
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+## Run the service
+
+Start Ollama in another terminal:
+
+```bash
+ollama serve
+```
+
+Run server directly (stdio transport):
+
+```bash
+smart-ide-service
+```
+
+Or run through FastMCP CLI (official docs style):
+
+```bash
+fastmcp run src/smart_ide_services/server.py:mcp
+```
+
+Run over HTTP transport when needed:
+
+```bash
+fastmcp run src/smart_ide_services/server.py:mcp --transport http --port 8000
+```
+
+## Call it from a FastMCP client
+
+When running with HTTP transport on port 8000:
+
+```python
+import asyncio
+from fastmcp import Client
+
+client = Client("http://localhost:8000/mcp")
+
+async def main() -> None:
+    async with client:
+        result = await client.call_tool("send_prompt", {"prompt": "Hello from Smart IDE"})
+        print(result.data)
+
+asyncio.run(main())
+```
+
+## MCP components
+
+### Tool: `send_prompt`
+
+Input:
+
+- `prompt` (string): user message.
+
+Output:
+
+- string response from local Ollama `qwen2.5vl:7b`.
+
+### Tool: `health_check`
+
+Output JSON includes:
+
+- configured Ollama URL
+- configured model
+- model availability flag
+- suggested `ollama pull` command when model is missing
+
+### Prompt: `chat_prompt`
+
+Input:
+
+- `user_message` (string)
+
+Output:
+
+- reusable prompt text message
+
+## Environment variables
+
+- `OLLAMA_URL`: Ollama base URL (default `http://127.0.0.1:11434`).
+- `OLLAMA_MODEL`: model name (default `qwen2.5vl:7b`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "smart-ide-services"
+version = "0.1.0"
+description = "FastMCP service that proxies prompts to local Ollama"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+  "fastmcp>=2.4,<4",
+  "httpx>=0.27.0",
+]
+
+[project.scripts]
+smart-ide-service = "smart_ide_services.server:main"
+
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/smart_ide_services/__init__.py
+++ b/src/smart_ide_services/__init__.py
@@ -1,0 +1,1 @@
+"""smart_ide_services package."""

--- a/src/smart_ide_services/server.py
+++ b/src/smart_ide_services/server.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
+
+SERVICE_NAME = "smart-ide-services"
+OLLAMA_URL = os.getenv("OLLAMA_URL", "http://127.0.0.1:11434")
+OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "qwen2.5vl:7b")
+
+mcp = FastMCP(name=SERVICE_NAME, mask_error_details=True)
+
+
+async def _chat_with_ollama(prompt: str) -> str:
+    """Send a prompt to the local Ollama instance and return generated text."""
+    if not prompt.strip():
+        raise ToolError("Prompt must not be empty.")
+
+    payload: dict[str, Any] = {
+        "model": OLLAMA_MODEL,
+        "messages": [{"role": "user", "content": prompt}],
+        "stream": False,
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            response = await client.post(f"{OLLAMA_URL}/api/chat", json=payload)
+            response.raise_for_status()
+            data = response.json()
+    except httpx.HTTPError as exc:
+        raise ToolError(
+            f"Failed to reach Ollama at {OLLAMA_URL}. Ensure 'ollama serve' is running."
+        ) from exc
+
+    message = data.get("message", {})
+    content = message.get("content")
+    if not content:
+        raise ToolError("Ollama returned an unexpected response shape.")
+    return content
+
+
+@mcp.tool(description="Send a user prompt to local Ollama and return the model output.")
+async def send_prompt(prompt: str) -> str:
+    """Receives a user prompt and returns model output from local Ollama."""
+    return await _chat_with_ollama(prompt)
+
+
+@mcp.tool(description="Check Ollama reachability and verify the configured model exists.")
+async def health_check() -> dict[str, Any]:
+    """Checks if Ollama is reachable and the configured model exists locally."""
+    try:
+        async with httpx.AsyncClient(timeout=20.0) as client:
+            tags_resp = await client.get(f"{OLLAMA_URL}/api/tags")
+            tags_resp.raise_for_status()
+            models = tags_resp.json().get("models", [])
+    except httpx.HTTPError as exc:
+        raise ToolError(
+            f"Ollama is not reachable at {OLLAMA_URL}. Start it with: ollama serve"
+        ) from exc
+
+    has_model = any(model.get("name") == OLLAMA_MODEL for model in models)
+    return {
+        "ollama_url": OLLAMA_URL,
+        "model": OLLAMA_MODEL,
+        "model_available": has_model,
+        "next_step": None if has_model else f"ollama pull {OLLAMA_MODEL}",
+    }
+
+
+@mcp.prompt
+def chat_prompt(user_message: str) -> str:
+    """Create a reusable prompt template for user chat messages."""
+    return f"User message: {user_message}"
+
+
+def main() -> None:
+    """Run as an MCP service (stdio transport by default)."""
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- Provide a small FastMCP backend that accepts user prompts and forwards them to a local Ollama model for the Smart IDE app.
- Expose a `send_prompt` tool for chat, a `health_check` tool for model availability verification, and a reusable `chat_prompt` template.
- Include a packaged entrypoint so the service can be run as a CLI or via `fastmcp` with sensible defaults for `OLLAMA_URL` and `OLLAMA_MODEL`.

### Description

- Add a new package `smart_ide_services` with `server.py` implementing a `FastMCP` instance and tools `send_prompt` and `health_check`, plus the `chat_prompt` prompt and `main()` runner.
- Implement Ollama communication with `httpx.AsyncClient` in `_chat_with_ollama` and use `ToolError` for user-facing errors on connectivity or unexpected responses.
- Add `pyproject.toml` with dependencies and a console script entrypoint `smart-ide-service` pointing to `smart_ide_services.server:main`.
- Add `README.md` documenting usage, prerequisites, environment variables (`OLLAMA_URL` and `OLLAMA_MODEL`), and `.gitignore` entries for Python caches.

### Testing

- No automated tests were included or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f068ddea348328a8a05665016ca6dd)