### PR TITLE
feat: add stack-specific backend generation skills and resolver

### DIFF
--- a/docs/mcp-skills-agents-tools.md
+++ b/docs/mcp-skills-agents-tools.md
@@ -1,0 +1,111 @@
+# MCP Skill, Agent, and Tool Blueprint (Backend-Focused)
+
+This document defines a starter catalog of **skills**, **agents**, and **MCP tools** aligned to your backend stacks:
+
+- Java (Spring Boot)
+- Node.js (Express + TypeScript)
+- Python (FastAPI)
+
+## 1) Skill catalog
+
+Skills are reusable capability bundles (instructions + workflows + guardrails).
+
+### Cross-stack core skills
+
+1. **api-design**
+   - Define REST resources, status codes, pagination, filtering, and error contracts.
+2. **auth-security**
+   - JWT/session handling, RBAC checks, OWASP validations, secrets handling.
+3. **data-modeling**
+   - Entity/schema design, migrations, indexing strategy, validation constraints.
+4. **testing-strategy**
+   - Unit/integration/e2e test design with fixture and mocking patterns.
+5. **observability**
+   - Logging, tracing, metrics, health/readiness/liveness standards.
+
+### Java Spring Boot skills
+
+1. **spring-api-implementation**
+   - Controllers, services, DTO mapping, validation, exception handlers.
+2. **spring-data-jpa**
+   - Repository methods, transaction boundaries, query optimization.
+3. **spring-boot-hardening**
+   - Profiles, config properties, actuator, resilience and retry patterns.
+
+### Node.js (Express + TypeScript) skills
+
+1. **express-route-architecture**
+   - Route-module boundaries, middleware order, error propagation.
+2. **typescript-domain-modeling**
+   - Types/interfaces/zod schemas and runtime validation strategy.
+3. **node-runtime-reliability**
+   - Process signals, graceful shutdown, async error handling, backpressure.
+
+### Python FastAPI skills
+
+1. **fastapi-endpoint-design**
+   - Router structure, pydantic models, dependency injection.
+2. **fastapi-async-io**
+   - Async path operations, clients, timeouts, cancellation-safe patterns.
+3. **python-service-operations**
+   - Settings management, startup checks, worker deployment conventions.
+
+## 2) Agent catalog
+
+Agents are role-specialized planners/executors that compose skills.
+
+1. **backend-architect-agent**
+   - Input: feature requirements.
+   - Output: service boundaries, module layout, contracts per stack.
+   - Uses: `api-design`, `data-modeling`, `observability`.
+
+2. **spring-implementation-agent**
+   - Input: Java feature ticket.
+   - Output: Spring controller/service/repository patch plan.
+   - Uses: `spring-api-implementation`, `spring-data-jpa`, `testing-strategy`.
+
+3. **express-ts-implementation-agent**
+   - Input: Node feature ticket.
+   - Output: route/service/schema/middleware plan.
+   - Uses: `express-route-architecture`, `typescript-domain-modeling`, `testing-strategy`.
+
+4. **fastapi-implementation-agent**
+   - Input: Python feature ticket.
+   - Output: router/service/schema/dependency plan.
+   - Uses: `fastapi-endpoint-design`, `fastapi-async-io`, `testing-strategy`.
+
+5. **backend-review-agent**
+   - Input: diff/PR summary.
+   - Output: correctness, security, and operability review comments.
+   - Uses: `auth-security`, `observability`, `testing-strategy`.
+
+## 3) MCP tool catalog (implementation targets)
+
+The following tools are designed to be exposed by the MCP server.
+
+1. `list_backend_blueprints`
+   - Returns supported stacks and available skills/agents.
+
+2. `generate_skill_set`
+   - Inputs: `stack`, `project_type`.
+   - Returns prioritized skills with rationale and checklist.
+
+3. `generate_agent_plan`
+   - Inputs: `stack`, `feature_summary`, `constraints`.
+   - Returns multi-step execution plan and handoff points.
+
+4. `generate_tool_spec`
+   - Inputs: `stack`, `capability`.
+   - Returns MCP tool contract (name, args schema, return schema, error guidance).
+
+5. `generate_backend_scaffold_tasks`
+   - Inputs: `stack`, `architecture_style`, `db_choice`.
+   - Returns scaffold task list for bootstrapping a new service.
+
+## 4) Suggested first workflow
+
+1. Call `list_backend_blueprints`.
+2. Call `generate_skill_set` for selected stack.
+3. Call `generate_agent_plan` for the first feature.
+4. Call `generate_tool_spec` for missing MCP capabilities.
+5. Execute scaffold tasks from `generate_backend_scaffold_tasks`.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,12 @@
+# Backend Generation Skills
+
+This directory contains reusable skills for stack-specific backend generation:
+
+- `generate-spring-boot-java-backend`
+- `generate-express-typescript-backend`
+- `generate-fastapi-python-backend`
+
+## Intent routing examples
+- "Create a backend in Java" -> `generate-spring-boot-java-backend`
+- "Create a Node backend with Express and TS" -> `generate-express-typescript-backend`
+- "Create a backend in Python using FastAPI" -> `generate-fastapi-python-backend`

--- a/skills/generate-express-typescript-backend.md
+++ b/skills/generate-express-typescript-backend.md
@@ -1,0 +1,24 @@
+# Skill: generate-express-typescript-backend
+
+## Trigger
+Use this skill when the user asks for Node.js backend generation with Express/TypeScript.
+
+## Goal
+Generate a maintainable Express + TypeScript backend scaffold and plan.
+
+## Guidelines
+1. Use Node 20+ and strict TypeScript config.
+2. Use modular layout: `routes`, `controllers`, `services`, `repositories`, `schemas`.
+3. Use runtime validation (zod or equivalent).
+4. Add centralized error middleware.
+5. Add health endpoint and structured logging.
+6. Ensure graceful shutdown and signal handling.
+7. Include auth/security baseline (JWT, secure headers, rate limiting).
+8. Include tests (unit + integration using supertest).
+
+## Deliverables
+- Project structure tree.
+- package dependencies and scripts.
+- API contract starter endpoints.
+- Validation and error-handling strategy.
+- Test plan and run commands.

--- a/skills/generate-fastapi-python-backend.md
+++ b/skills/generate-fastapi-python-backend.md
@@ -1,0 +1,24 @@
+# Skill: generate-fastapi-python-backend
+
+## Trigger
+Use this skill when the user asks for Python backend generation with FastAPI.
+
+## Goal
+Generate an async-first FastAPI backend scaffold and implementation plan.
+
+## Guidelines
+1. Use Python 3.11+ and FastAPI with pydantic models.
+2. Use module boundaries: `routers`, `services`, `clients`, `domain`, `schemas`.
+3. Prefer async I/O for network and DB paths.
+4. Add health/readiness endpoints.
+5. Add settings via environment-backed configuration.
+6. Add auth/security baseline (JWT/OAuth2 scopes as needed).
+7. Add structured logging and request IDs.
+8. Include tests (pytest + httpx AsyncClient).
+
+## Deliverables
+- Project structure tree.
+- Dependency list and app bootstrap.
+- Starter routers and schema contracts.
+- Observability/security checklist.
+- Test plan and run commands.

--- a/skills/generate-spring-boot-java-backend.md
+++ b/skills/generate-spring-boot-java-backend.md
@@ -1,0 +1,24 @@
+# Skill: generate-spring-boot-java-backend
+
+## Trigger
+Use this skill when the user asks for Java backend generation, e.g. "Create a backend in Java".
+
+## Goal
+Generate a production-oriented Spring Boot backend scaffold and implementation plan.
+
+## Guidelines
+1. Use Java 21+ and Spring Boot 3.x.
+2. Prefer layered architecture: `controller -> service -> repository -> domain`.
+3. Add DTO validation with Jakarta Validation.
+4. Add centralized exception handling (`@ControllerAdvice`).
+5. Include health/readiness endpoints via Spring Actuator.
+6. Add config profile strategy (`dev`, `test`, `prod`).
+7. Include auth/security baseline (JWT + role checks).
+8. Include testing baseline (unit + integration with Testcontainers if DB is used).
+
+## Deliverables
+- Project structure tree.
+- Core dependencies.
+- Initial endpoints (`/health`, `/api/v1/*`).
+- Data model + migration strategy.
+- Test plan and run commands.

--- a/src/server.py
+++ b/src/server.py
@@ -13,6 +13,87 @@ OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "qwen2.5vl:7b")
 
 mcp = FastMCP(name=SERVICE_NAME, mask_error_details=True)
 
+BLUEPRINTS: dict[str, dict[str, list[str]]] = {
+    "java_spring_boot": {
+        "skills": [
+            "api-design",
+            "auth-security",
+            "data-modeling",
+            "testing-strategy",
+            "observability",
+            "spring-api-implementation",
+            "generate-spring-boot-java-backend",
+            "spring-data-jpa",
+            "spring-boot-hardening",
+        ],
+        "agents": [
+            "backend-architect-agent",
+            "spring-implementation-agent",
+            "backend-review-agent",
+        ],
+    },
+    "node_express_typescript": {
+        "skills": [
+            "api-design",
+            "auth-security",
+            "data-modeling",
+            "testing-strategy",
+            "observability",
+            "express-route-architecture",
+            "generate-express-typescript-backend",
+            "typescript-domain-modeling",
+            "node-runtime-reliability",
+        ],
+        "agents": [
+            "backend-architect-agent",
+            "express-ts-implementation-agent",
+            "backend-review-agent",
+        ],
+    },
+    "python_fastapi": {
+        "skills": [
+            "api-design",
+            "auth-security",
+            "data-modeling",
+            "testing-strategy",
+            "observability",
+            "fastapi-endpoint-design",
+            "generate-fastapi-python-backend",
+            "fastapi-async-io",
+            "python-service-operations",
+        ],
+        "agents": [
+            "backend-architect-agent",
+            "fastapi-implementation-agent",
+            "backend-review-agent",
+        ],
+    },
+}
+
+
+def _normalize_stack(stack: str) -> str:
+    return stack.strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _resolve_stack(stack: str) -> str:
+    key = _normalize_stack(stack)
+    aliases = {
+        "java": "java_spring_boot",
+        "spring_boot": "java_spring_boot",
+        "nodejs": "node_express_typescript",
+        "node": "node_express_typescript",
+        "express": "node_express_typescript",
+        "typescript": "node_express_typescript",
+        "python": "python_fastapi",
+        "fastapi": "python_fastapi",
+    }
+    key = aliases.get(key, key)
+    if key not in BLUEPRINTS:
+        raise ToolError(
+            f"Unsupported stack '{stack}'. Use one of: {', '.join(BLUEPRINTS.keys())}"
+        )
+    return key
+
 
 async def _chat_with_ollama(prompt: str) -> str:
     """Send a prompt to the local Ollama instance and return generated text."""
@@ -68,6 +149,81 @@ async def health_check() -> dict[str, Any]:
         "model_available": has_model,
         "next_step": None if has_model else f"ollama pull {OLLAMA_MODEL}",
     }
+
+
+@mcp.tool(description="List supported backend blueprints, skills, and agents.")
+async def list_backend_blueprints() -> dict[str, Any]:
+    """Return supported backend stacks and their skill/agent bundles."""
+    return {"stacks": BLUEPRINTS}
+
+
+@mcp.tool(description="Generate a prioritized skill set for a backend stack.")
+async def generate_skill_set(stack: str, project_type: str = "api") -> dict[str, Any]:
+    """Return recommended skill ordering for a selected stack."""
+    stack_key = _resolve_stack(stack)
+    skills = BLUEPRINTS[stack_key]["skills"]
+    return {
+        "stack": stack_key,
+        "project_type": project_type,
+        "priority_skills": skills,
+        "checklist": [
+            "Define API contract and error schema",
+            "Set auth/security and validation rules",
+            "Implement observability and health endpoints",
+            "Create unit and integration tests",
+        ],
+    }
+
+
+@mcp.tool(description="Generate an agent execution plan for a backend feature.")
+async def generate_agent_plan(
+    stack: str, feature_summary: str, constraints: str = ""
+) -> dict[str, Any]:
+    """Return a role-based implementation plan for a feature request."""
+    if not feature_summary.strip():
+        raise ToolError("feature_summary must not be empty.")
+
+    stack_key = _resolve_stack(stack)
+    agents = BLUEPRINTS[stack_key]["agents"]
+    return {
+        "stack": stack_key,
+        "feature_summary": feature_summary,
+        "constraints": constraints,
+        "plan": [
+            {"step": 1, "agent": agents[0], "task": "Design architecture and contracts"},
+            {"step": 2, "agent": agents[1], "task": "Implement feature modules and tests"},
+            {"step": 3, "agent": agents[2], "task": "Run review checklist and release readiness"},
+        ],
+    }
+
+
+@mcp.tool(description="Resolve a user request to a recommended backend generation skill.")
+async def resolve_backend_skill(user_request: str) -> dict[str, str]:
+    """Map plain-language requests to a stack-specific backend generation skill."""
+    text = user_request.strip().lower()
+    if not text:
+        raise ToolError("user_request must not be empty.")
+
+    if "java" in text or "spring" in text:
+        return {
+            "stack": "java_spring_boot",
+            "skill": "generate-spring-boot-java-backend",
+            "reason": "Detected Java/Spring intent.",
+        }
+    if "node" in text or "express" in text or "typescript" in text:
+        return {
+            "stack": "node_express_typescript",
+            "skill": "generate-express-typescript-backend",
+            "reason": "Detected Node/Express/TypeScript intent.",
+        }
+    if "python" in text or "fastapi" in text:
+        return {
+            "stack": "python_fastapi",
+            "skill": "generate-fastapi-python-backend",
+            "reason": "Detected Python/FastAPI intent.",
+        }
+
+    raise ToolError("Could not infer stack. Mention Java, Node/Express/TypeScript, or Python/FastAPI.")
 
 
 @mcp.prompt


### PR DESCRIPTION
## What changed
- Added stack-specific skill definitions under `skills/`:
  - `generate-spring-boot-java-backend`
  - `generate-express-typescript-backend`
  - `generate-fastapi-python-backend`
- Added `skills/README.md` with explicit intent routing examples (including "Create a backend in Java").
- Updated `src/server.py` blueprint skill lists to include the new generation skills.
- Added MCP tool `resolve_backend_skill(user_request: str)` to map plain-language requests to the appropriate skill.

## Why it changed
The request asked for pre-created skills that the IDE can recognize and reuse by intent, specifically with examples like "Create a backend in Java" selecting an existing Spring Boot skill.

## Validation
- `python -m compileall src` ✅ passed.
- `pytest` ⚠️ no tests were collected (exit code 5).

## Follow-up work
- Add unit tests for `resolve_backend_skill` routing and edge cases.
- Optionally add a skill loader/index endpoint if your IDE expects a formal registry contract.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f31a3d243883288ee5dc42e4b74806)