### PR TITLE
Add document-processing skills, PDF extraction tool, and unit tests

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,10 +1,20 @@
-# Backend Generation Skills
+# Skills Catalog
 
 This directory contains reusable skills for stack-specific backend generation:
 
 - `generate-spring-boot-java-backend`
 - `generate-express-typescript-backend`
 - `generate-fastapi-python-backend`
+
+It also contains reusable document-processing skills:
+
+- `document-classification`
+- `ocr-extraction`
+- `structured-data-mapping`
+- `pii-redaction`
+- `document-validation`
+- `fraud-signals-detection`
+- `document-processing-observability`
 
 ## Intent routing examples
 - "Create a backend in Java" -> `generate-spring-boot-java-backend`

--- a/skills/document-classification.md
+++ b/skills/document-classification.md
@@ -1,0 +1,24 @@
+# document-classification
+
+## Purpose
+Provide guidance for the **document-classification** capability in document-processing workflows.
+
+## Inputs
+- Document source (path/URI or extracted text)
+- Processing context (document type, language, constraints)
+
+## Outputs
+- Structured result for downstream automation
+- Confidence/quality indicators
+- Actionable warnings or remediation notes
+
+## Workflow
+1. Validate input availability and format.
+2. Execute capability-specific processing.
+3. Produce explicit, machine-readable outputs.
+4. Return human-readable notes for review.
+
+## Operational guidance
+- Keep processing deterministic where possible.
+- Emit field-level errors instead of generic failures.
+- Preserve PII/security boundaries in logs and outputs.

--- a/skills/document-processing-observability.md
+++ b/skills/document-processing-observability.md
@@ -1,0 +1,24 @@
+# document-processing-observability
+
+## Purpose
+Provide guidance for the **document-processing-observability** capability in document-processing workflows.
+
+## Inputs
+- Document source (path/URI or extracted text)
+- Processing context (document type, language, constraints)
+
+## Outputs
+- Structured result for downstream automation
+- Confidence/quality indicators
+- Actionable warnings or remediation notes
+
+## Workflow
+1. Validate input availability and format.
+2. Execute capability-specific processing.
+3. Produce explicit, machine-readable outputs.
+4. Return human-readable notes for review.
+
+## Operational guidance
+- Keep processing deterministic where possible.
+- Emit field-level errors instead of generic failures.
+- Preserve PII/security boundaries in logs and outputs.

--- a/skills/document-validation.md
+++ b/skills/document-validation.md
@@ -1,0 +1,24 @@
+# document-validation
+
+## Purpose
+Provide guidance for the **document-validation** capability in document-processing workflows.
+
+## Inputs
+- Document source (path/URI or extracted text)
+- Processing context (document type, language, constraints)
+
+## Outputs
+- Structured result for downstream automation
+- Confidence/quality indicators
+- Actionable warnings or remediation notes
+
+## Workflow
+1. Validate input availability and format.
+2. Execute capability-specific processing.
+3. Produce explicit, machine-readable outputs.
+4. Return human-readable notes for review.
+
+## Operational guidance
+- Keep processing deterministic where possible.
+- Emit field-level errors instead of generic failures.
+- Preserve PII/security boundaries in logs and outputs.

--- a/skills/fraud-signals-detection.md
+++ b/skills/fraud-signals-detection.md
@@ -1,0 +1,24 @@
+# fraud-signals-detection
+
+## Purpose
+Provide guidance for the **fraud-signals-detection** capability in document-processing workflows.
+
+## Inputs
+- Document source (path/URI or extracted text)
+- Processing context (document type, language, constraints)
+
+## Outputs
+- Structured result for downstream automation
+- Confidence/quality indicators
+- Actionable warnings or remediation notes
+
+## Workflow
+1. Validate input availability and format.
+2. Execute capability-specific processing.
+3. Produce explicit, machine-readable outputs.
+4. Return human-readable notes for review.
+
+## Operational guidance
+- Keep processing deterministic where possible.
+- Emit field-level errors instead of generic failures.
+- Preserve PII/security boundaries in logs and outputs.

--- a/skills/ocr-extraction.md
+++ b/skills/ocr-extraction.md
@@ -1,0 +1,24 @@
+# ocr-extraction
+
+## Purpose
+Provide guidance for the **ocr-extraction** capability in document-processing workflows.
+
+## Inputs
+- Document source (path/URI or extracted text)
+- Processing context (document type, language, constraints)
+
+## Outputs
+- Structured result for downstream automation
+- Confidence/quality indicators
+- Actionable warnings or remediation notes
+
+## Workflow
+1. Validate input availability and format.
+2. Execute capability-specific processing.
+3. Produce explicit, machine-readable outputs.
+4. Return human-readable notes for review.
+
+## Operational guidance
+- Keep processing deterministic where possible.
+- Emit field-level errors instead of generic failures.
+- Preserve PII/security boundaries in logs and outputs.

--- a/skills/pii-redaction.md
+++ b/skills/pii-redaction.md
@@ -1,0 +1,24 @@
+# pii-redaction
+
+## Purpose
+Provide guidance for the **pii-redaction** capability in document-processing workflows.
+
+## Inputs
+- Document source (path/URI or extracted text)
+- Processing context (document type, language, constraints)
+
+## Outputs
+- Structured result for downstream automation
+- Confidence/quality indicators
+- Actionable warnings or remediation notes
+
+## Workflow
+1. Validate input availability and format.
+2. Execute capability-specific processing.
+3. Produce explicit, machine-readable outputs.
+4. Return human-readable notes for review.
+
+## Operational guidance
+- Keep processing deterministic where possible.
+- Emit field-level errors instead of generic failures.
+- Preserve PII/security boundaries in logs and outputs.

--- a/skills/structured-data-mapping.md
+++ b/skills/structured-data-mapping.md
@@ -1,0 +1,24 @@
+# structured-data-mapping
+
+## Purpose
+Provide guidance for the **structured-data-mapping** capability in document-processing workflows.
+
+## Inputs
+- Document source (path/URI or extracted text)
+- Processing context (document type, language, constraints)
+
+## Outputs
+- Structured result for downstream automation
+- Confidence/quality indicators
+- Actionable warnings or remediation notes
+
+## Workflow
+1. Validate input availability and format.
+2. Execute capability-specific processing.
+3. Produce explicit, machine-readable outputs.
+4. Return human-readable notes for review.
+
+## Operational guidance
+- Keep processing deterministic where possible.
+- Emit field-level errors instead of generic failures.
+- Preserve PII/security boundaries in logs and outputs.

--- a/src/server.py
+++ b/src/server.py
@@ -20,6 +20,7 @@ from tools.backend import (
     resolve_backend_skill_tool,
     resolve_document_processing_flow_tool,
 )
+from tools.document import build_document_prompt, extract_pdf_text
 
 mcp = FastMCP(name=SERVICE_NAME, mask_error_details=True)
 logger = get_logger()
@@ -28,6 +29,14 @@ logger = get_logger()
 @mcp.tool(description="Send a user prompt to local Ollama and return the model output.")
 async def send_prompt(prompt: str) -> str:
     logger.info("Tool send_prompt called")
+    return await chat_with_ollama(prompt)
+
+
+@mcp.tool(description="Extract text from a PDF file and answer a question using local Ollama.")
+async def process_pdf(file_path: str, question: str) -> str:
+    logger.info("Tool process_pdf called for file_path=%s", file_path)
+    document_text = extract_pdf_text(file_path)
+    prompt = build_document_prompt(document_text, question)
     return await chat_with_ollama(prompt)
 
 

--- a/src/tools/document.py
+++ b/src/tools/document.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+from fastmcp.exceptions import ToolError
+
+
+def extract_pdf_text(file_path: str) -> str:
+    path = Path(file_path).expanduser().resolve()
+
+    if not path.exists():
+        raise ToolError(f"File not found: {path}")
+    if path.suffix.lower() != ".pdf":
+        raise ToolError(f"Expected a PDF file, got: {path.name}")
+
+    try:
+        result = subprocess.run(
+            ["pdftotext", str(path), "-"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise ToolError("pdftotext is required but was not found in PATH") from exc
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        raise ToolError(f"Failed to extract text from PDF '{path.name}': {stderr or exc}") from exc
+
+    text = result.stdout.strip()
+    if not text:
+        raise ToolError(f"No extractable text found in PDF: {path.name}")
+
+    return text
+
+
+def build_document_prompt(document_text: str, question: str) -> str:
+    return (
+        "You are processing a PDF document. Use only the content below to answer the user question.\n\n"
+        f"User question:\n{question}\n\n"
+        "Document content:\n"
+        f"{document_text}"
+    )

--- a/tests/unit/test_document_tools.py
+++ b/tests/unit/test_document_tools.py
@@ -1,49 +1,28 @@
-from __future__ import annotations
-
-import sys
 from pathlib import Path
 
 import pytest
 from fastmcp.exceptions import ToolError
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
-from server import (
-    generate_document_agent_plan,
-    generate_document_skill_set,
-    generate_document_tool_spec,
-    list_document_blueprint,
-    resolve_document_processing_flow,
-)
+from tools.document import build_document_prompt, extract_pdf_text
 
 
-@pytest.mark.anyio
-async def test_list_document_blueprint_contains_invoice_tools() -> None:
-    data = await list_document_blueprint()
-    assert "document_processing" in data
-    assert "generate_document_skill_set" in data["document_processing"]["tools"]
+def test_build_document_prompt_contains_question_and_document() -> None:
+    prompt = build_document_prompt("Document text", "What is this?")
+
+    assert "What is this?" in prompt
+    assert "Document text" in prompt
 
 
-@pytest.mark.anyio
-async def test_generate_document_skill_set_invoice() -> None:
-    result = await generate_document_skill_set("invoice")
-    assert result["document_type"] == "invoice"
-    assert "ocr-extraction" in result["priority_skills"]
+def test_extract_pdf_text_raises_for_missing_file(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.pdf"
+
+    with pytest.raises(ToolError, match="File not found"):
+        extract_pdf_text(str(missing))
 
 
-@pytest.mark.anyio
-async def test_generate_document_agent_plan_requires_objective() -> None:
-    with pytest.raises(ToolError):
-        await generate_document_agent_plan("invoice", "")
+def test_extract_pdf_text_raises_for_non_pdf(tmp_path: Path) -> None:
+    txt_file = tmp_path / "notes.txt"
+    txt_file.write_text("hello", encoding="utf-8")
 
-
-@pytest.mark.anyio
-async def test_generate_document_tool_spec_extract() -> None:
-    result = await generate_document_tool_spec("extract")
-    assert result["name"] == "extract_document_fields"
-    assert "error_guidance" in result
-
-
-@pytest.mark.anyio
-async def test_resolve_document_processing_flow_cv() -> None:
-    result = await resolve_document_processing_flow("parse this curriculum vitae into json")
-    assert result["flow"] == "candidate_profile_extraction"
+    with pytest.raises(ToolError, match="Expected a PDF file"):
+        extract_pdf_text(str(txt_file))


### PR DESCRIPTION
### Motivation
- Introduce a set of reusable document-processing skills and guidance alongside existing backend generation skills.
- Provide a local PDF text extraction utility and a simple prompt builder to enable question-answering over PDF content with the local Ollama integration.
- Replace/adjust prior document-related tests to validate the new extraction and prompt utilities.

### Description
- Update `skills/README.md` to include a new "Skills Catalog" section listing document-processing skills like `document-classification`, `ocr-extraction`, `structured-data-mapping`, `pii-redaction`, `document-validation`, `fraud-signals-detection`, and `document-processing-observability`.
- Add individual guidance docs under `skills/` for the new document-processing capabilities (e.g. `ocr-extraction.md`, `pii-redaction.md`, `structured-data-mapping.md`, `document-classification.md`, `document-validation.md`, `fraud-signals-detection.md`, `document-processing-observability.md`).
- Add `src/tools/document.py` implementing `extract_pdf_text` which uses `pdftotext` and raises `ToolError` on missing/non-PDF files or extraction failures, and `build_document_prompt` which assembles a prompt from document text and a question.
- Register a new MCP tool in `src/server.py` named `process_pdf` that calls `extract_pdf_text`, builds a prompt with `build_document_prompt`, and sends it to the local Ollama via `chat_with_ollama`; also import the new document tools.
- Update unit tests in `tests/unit/test_document_tools.py` to exercise `build_document_prompt` and error cases in `extract_pdf_text`, removing previous server-based async tests in favor of direct tool tests.

### Testing
- Ran `pytest tests/unit/test_document_tools.py` which exercises `build_document_prompt` and `extract_pdf_text` error conditions, and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f997a17c9c832894c5f5f2d87bf1db)