### PR TITLE
Add Starlette HTTP API for frontend prompt routing and execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,72 @@ OLLAMA_TIMEOUT_SECONDS=600 python src/server.py
 ```
 
 If you still get timeouts, try reducing prompt size by passing `max_chars` in `process_pdf`.
+
+## Frontend prompt router API
+
+The HTTP API exposes prompt routing endpoints that a frontend can call before or during prompt execution.
+
+### Run the HTTP API locally
+
+Install the project dependencies, then start Uvicorn from the repository root:
+
+```bash
+python -m pip install -e .
+uvicorn http_api:app --app-dir src --reload
+```
+
+A route summary is available at `http://127.0.0.1:8000/`. Swagger UI is available at `http://127.0.0.1:8000/docs`, and the OpenAPI schema is available at `http://127.0.0.1:8000/openapi.json`.
+
+
+### Test with Swagger UI `/docs`
+
+Yes. After starting Uvicorn, open `http://127.0.0.1:8000/docs` in your browser. You can expand:
+
+- `GET /api/prompts/route`, click **Try it out**, enter a prompt such as `Create a Python FastAPI backend`, and execute it.
+- `POST /api/prompts/execute`, click **Try it out**, use a JSON body such as `{"prompt":"Process an invoice document"}`, and execute it.
+
+The Swagger page is backed by `http://127.0.0.1:8000/openapi.json`.
+
+### GET `/api/prompts/route`
+
+Use this endpoint when the frontend has a prompt and wants to know which backend tool should handle it.
+
+```bash
+curl "http://127.0.0.1:8000/api/prompts/route?prompt=Create%20a%20Python%20FastAPI%20backend"
+```
+
+Example response:
+
+```json
+{
+  "prompt": "Create a Python FastAPI backend",
+  "category": "backend",
+  "tool_name": "resolve_backend_skill",
+  "reason": "Detected backend-generation intent."
+}
+```
+
+### POST `/api/prompts/execute`
+
+Use this endpoint when the frontend wants the API to execute the prompt by calling the inferred tool.
+
+```bash
+curl -X POST "http://127.0.0.1:8000/api/prompts/execute" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt":"Process an invoice document"}'
+```
+
+You can also force a specific supported tool with `tool_name` and pass tool-specific `arguments`:
+
+```bash
+curl -X POST "http://127.0.0.1:8000/api/prompts/execute" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt":"Create a document tool","tool_name":"generate_document_tool_spec","arguments":{"capability":"redact"}}'
+```
+
+Router validation is covered by unit tests and can be checked with:
+
+```bash
+python -m compileall src tests
+pytest -q
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ requires-python = ">=3.10"
 dependencies = [
   "fastmcp>=2.4,<4",
   "httpx>=0.27.0",
+  "starlette>=0.37.0,<2",
+  "uvicorn[standard]>=0.30.0,<1",
 ]
 
 [project.scripts]

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from typing import Any
+
+from starlette.applications import Starlette
+from starlette.responses import HTMLResponse, JSONResponse, Response
+from starlette.routing import Route
+
+from config import SERVICE_NAME
+from routers.prompt import router as prompt_router
+from services.prompt_router import (
+    PromptExecutionRequest,
+    PromptExecutionResponse,
+    PromptRoute,
+)
+
+
+def build_openapi_schema() -> dict[str, Any]:
+    return {
+        "openapi": "3.1.0",
+        "info": {
+            "title": SERVICE_NAME,
+            "version": "0.1.0",
+            "description": "HTTP API for frontend prompt routing and execution.",
+        },
+        "paths": {
+            "/api/prompts/route": {
+                "get": {
+                    "tags": ["prompts"],
+                    "summary": "Route a frontend prompt to the recommended tool.",
+                    "parameters": [
+                        {
+                            "name": "prompt",
+                            "in": "query",
+                            "required": True,
+                            "description": "Prompt message from the frontend.",
+                            "schema": {"type": "string", "minLength": 1},
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Recommended prompt route.",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/PromptRoute"}
+                                }
+                            },
+                        },
+                        "400": {"description": "Invalid prompt."},
+                    },
+                }
+            },
+            "/api/prompts/execute": {
+                "post": {
+                    "tags": ["prompts"],
+                    "summary": "Execute a frontend prompt using the inferred or requested tool.",
+                    "requestBody": {
+                        "required": True,
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PromptExecutionRequest"
+                                }
+                            }
+                        },
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Prompt execution result.",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/PromptExecutionResponse"
+                                    }
+                                }
+                            },
+                        },
+                        "400": {"description": "Invalid prompt or tool arguments."},
+                        "422": {"description": "Invalid request body."},
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "PromptRoute": PromptRoute.model_json_schema(ref_template="#/components/schemas/{model}"),
+                "PromptExecutionRequest": PromptExecutionRequest.model_json_schema(
+                    ref_template="#/components/schemas/{model}"
+                ),
+                "PromptExecutionResponse": PromptExecutionResponse.model_json_schema(
+                    ref_template="#/components/schemas/{model}"
+                ),
+            }
+        },
+    }
+
+
+async def openapi_schema(_: object) -> Response:
+    return JSONResponse(build_openapi_schema())
+
+
+async def swagger_docs(_: object) -> Response:
+    return HTMLResponse(
+        """
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Smart IDE Services API Docs</title>
+    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css" />
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+    <script>
+      window.ui = SwaggerUIBundle({
+        url: '/openapi.json',
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        presets: [SwaggerUIBundle.presets.apis],
+      });
+    </script>
+  </body>
+</html>
+""".strip()
+    )
+
+
+async def api_hint(_: object) -> Response:
+    return JSONResponse(
+        {
+            "service": SERVICE_NAME,
+            "routes": [
+                "GET /api/prompts/route?prompt=...",
+                "POST /api/prompts/execute",
+            ],
+            "docs": "Open Swagger UI at /docs or fetch the OpenAPI schema at /openapi.json.",
+        }
+    )
+
+
+def create_app() -> Starlette:
+    return Starlette(
+        debug=False,
+        routes=[
+            Route("/", api_hint, methods=["GET"]),
+            Route("/docs", swagger_docs, methods=["GET"]),
+            Route("/openapi.json", openapi_schema, methods=["GET"]),
+            *prompt_router.routes,
+        ],
+    )
+
+
+app = create_app()

--- a/src/routers/prompt.py
+++ b/src/routers/prompt.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from json import JSONDecodeError
+
+from fastmcp.exceptions import ToolError
+from pydantic import ValidationError
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import Route, Router
+from starlette.status import HTTP_400_BAD_REQUEST
+
+from services.prompt_router import (
+    PromptExecutionRequest,
+    execute_prompt_tool,
+    route_prompt,
+)
+
+
+async def get_prompt_route(request: Request) -> Response:
+    prompt = request.query_params.get("prompt", "")
+    try:
+        route = route_prompt(prompt)
+    except ToolError as exc:
+        return JSONResponse({"detail": str(exc)}, status_code=HTTP_400_BAD_REQUEST)
+
+    return JSONResponse(route.model_dump())
+
+
+async def post_prompt_execute(request: Request) -> Response:
+    try:
+        payload = await request.json()
+        execution_request = PromptExecutionRequest.model_validate(payload)
+        response = await execute_prompt_tool(execution_request)
+    except JSONDecodeError as exc:
+        return JSONResponse({"detail": str(exc)}, status_code=HTTP_400_BAD_REQUEST)
+    except ValidationError as exc:
+        return JSONResponse(
+            {"detail": exc.errors()},
+            status_code=422,
+        )
+    except ToolError as exc:
+        return JSONResponse({"detail": str(exc)}, status_code=HTTP_400_BAD_REQUEST)
+
+    return JSONResponse(response.model_dump())
+
+
+router = Router(
+    routes=[
+        Route("/api/prompts/route", get_prompt_route, methods=["GET"]),
+        Route("/api/prompts/execute", post_prompt_execute, methods=["POST"]),
+    ]
+)

--- a/src/services/prompt_router.py
+++ b/src/services/prompt_router.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Literal
+
+from fastmcp.exceptions import ToolError
+from pydantic import BaseModel, ConfigDict, Field
+
+from clients.ollama import chat_with_ollama, ollama_health
+from tools.backend import (
+    generate_agent_plan_tool,
+    generate_document_agent_plan_tool,
+    generate_document_skill_set_tool,
+    generate_document_tool_spec_tool,
+    generate_skill_set_tool,
+    list_backend_blueprints_tool,
+    list_document_blueprint_tool,
+    list_platform_blueprints_tool,
+    resolve_backend_skill_tool,
+    resolve_document_processing_flow_tool,
+)
+
+PromptCategory = Literal["backend", "document", "health", "chat"]
+
+
+class PromptRoute(BaseModel):
+    prompt: str
+    category: PromptCategory
+    tool_name: str
+    reason: str
+
+
+class PromptExecutionRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    prompt: str = Field(..., min_length=1)
+    tool_name: str | None = None
+    arguments: dict[str, Any] = Field(default_factory=dict)
+
+
+class PromptExecutionResponse(BaseModel):
+    prompt: str
+    tool_name: str
+    arguments: dict[str, Any]
+    result: Any
+
+
+def route_prompt(prompt: str) -> PromptRoute:
+    text = prompt.strip().lower()
+    if not text:
+        raise ToolError("prompt must not be empty.")
+
+    if any(token in text for token in ("health", "status", "ollama", "reachable")):
+        return PromptRoute(
+            prompt=prompt,
+            category="health",
+            tool_name="health_check",
+            reason="Detected health/status intent.",
+        )
+
+    if any(
+        token in text
+        for token in (
+            "invoice",
+            "cv",
+            "resume",
+            "curriculum vitae",
+            "document",
+            "pdf",
+            "ocr",
+            "redact",
+            "pii",
+            "extract fields",
+            "validate document",
+        )
+    ):
+        return PromptRoute(
+            prompt=prompt,
+            category="document",
+            tool_name="resolve_document_processing_flow",
+            reason="Detected document-processing intent.",
+        )
+
+    if any(
+        token in text
+        for token in (
+            "backend",
+            "api",
+            "java",
+            "spring",
+            "node",
+            "express",
+            "typescript",
+            "python",
+            "fastapi",
+        )
+    ):
+        return PromptRoute(
+            prompt=prompt,
+            category="backend",
+            tool_name="resolve_backend_skill",
+            reason="Detected backend-generation intent.",
+        )
+
+    return PromptRoute(
+        prompt=prompt,
+        category="chat",
+        tool_name="send_prompt",
+        reason="No specialized tool intent detected; using general model chat.",
+    )
+
+
+def _argument(arguments: dict[str, Any], name: str, fallback: Any = None) -> Any:
+    return arguments[name] if name in arguments else fallback
+
+
+def _required_argument(arguments: dict[str, Any], name: str) -> Any:
+    if name not in arguments or arguments[name] in (None, ""):
+        raise ToolError(f"arguments.{name} is required for this tool.")
+    return arguments[name]
+
+
+async def execute_prompt_tool(
+    request: PromptExecutionRequest,
+) -> PromptExecutionResponse:
+    route = route_prompt(request.prompt)
+    tool_name = request.tool_name or route.tool_name
+    arguments = dict(request.arguments)
+
+    result = await _execute_tool(tool_name, request.prompt, arguments)
+
+    return PromptExecutionResponse(
+        prompt=request.prompt,
+        tool_name=tool_name,
+        arguments=arguments,
+        result=result,
+    )
+
+
+async def _execute_tool(tool_name: str, prompt: str, arguments: dict[str, Any]) -> Any:
+    async_tools: dict[str, Callable[[], Any]] = {
+        "send_prompt": lambda: chat_with_ollama(str(_argument(arguments, "prompt", prompt))),
+        "health_check": ollama_health,
+    }
+    if tool_name in async_tools:
+        return await async_tools[tool_name]()
+
+    sync_tools: dict[str, Callable[[], Any]] = {
+        "list_backend_blueprints": list_backend_blueprints_tool,
+        "list_platform_blueprints": list_platform_blueprints_tool,
+        "list_document_blueprint": list_document_blueprint_tool,
+        "resolve_backend_skill": lambda: resolve_backend_skill_tool(
+            str(_argument(arguments, "user_request", prompt))
+        ),
+        "generate_skill_set": lambda: generate_skill_set_tool(
+            str(_required_argument(arguments, "stack")),
+            str(_argument(arguments, "project_type", "api")),
+        ),
+        "generate_agent_plan": lambda: generate_agent_plan_tool(
+            str(_required_argument(arguments, "stack")),
+            str(_argument(arguments, "feature_summary", prompt)),
+            str(_argument(arguments, "constraints", "")),
+        ),
+        "resolve_document_processing_flow": lambda: resolve_document_processing_flow_tool(
+            str(_argument(arguments, "user_request", prompt))
+        ),
+        "generate_document_skill_set": lambda: generate_document_skill_set_tool(
+            str(_required_argument(arguments, "document_type")),
+            str(_argument(arguments, "compliance_mode", "standard")),
+        ),
+        "generate_document_agent_plan": lambda: generate_document_agent_plan_tool(
+            str(_required_argument(arguments, "document_type")),
+            str(_argument(arguments, "objective", prompt)),
+            str(_argument(arguments, "constraints", "")),
+        ),
+        "generate_document_tool_spec": lambda: generate_document_tool_spec_tool(
+            str(_required_argument(arguments, "capability"))
+        ),
+    }
+    if tool_name not in sync_tools:
+        supported_tools = sorted([*async_tools.keys(), *sync_tools.keys()])
+        raise ToolError(
+            f"Unsupported tool_name '{tool_name}'. Use one of: {', '.join(supported_tools)}"
+        )
+
+    return sync_tools[tool_name]()

--- a/tests/unit/test_prompt_router.py
+++ b/tests/unit/test_prompt_router.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+from fastmcp.exceptions import ToolError
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+from http_api import create_app
+from services.prompt_router import PromptExecutionRequest, execute_prompt_tool, route_prompt
+
+
+def test_route_prompt_detects_backend_intent() -> None:
+    route = route_prompt("Create a Python FastAPI backend")
+
+    assert route.category == "backend"
+    assert route.tool_name == "resolve_backend_skill"
+
+
+def test_route_prompt_detects_document_intent() -> None:
+    route = route_prompt("Extract invoice fields from this PDF")
+
+    assert route.category == "document"
+    assert route.tool_name == "resolve_document_processing_flow"
+
+
+def test_route_prompt_rejects_blank_prompt() -> None:
+    with pytest.raises(ToolError, match="prompt must not be empty"):
+        route_prompt("   ")
+
+
+@pytest.mark.anyio
+async def test_execute_prompt_tool_calls_inferred_backend_tool() -> None:
+    response = await execute_prompt_tool(
+        PromptExecutionRequest(prompt="Build Node API with Express and TypeScript")
+    )
+
+    assert response.tool_name == "resolve_backend_skill"
+    assert response.result["stack"] == "node_express_typescript"
+
+
+@pytest.mark.anyio
+async def test_execute_prompt_tool_calls_explicit_document_tool() -> None:
+    response = await execute_prompt_tool(
+        PromptExecutionRequest(
+            prompt="I need redaction support",
+            tool_name="generate_document_tool_spec",
+            arguments={"capability": "redact"},
+        )
+    )
+
+    assert response.tool_name == "generate_document_tool_spec"
+    assert response.result["name"] == "redact_document"
+
+
+def test_get_prompt_route_endpoint() -> None:
+    client = TestClient(create_app())
+
+    response = client.get("/api/prompts/route", params={"prompt": "Need a Java backend"})
+
+    assert response.status_code == 200
+    assert response.json()["tool_name"] == "resolve_backend_skill"
+
+
+def test_post_prompt_execute_endpoint() -> None:
+    client = TestClient(create_app())
+
+    response = client.post(
+        "/api/prompts/execute",
+        json={"prompt": "Process a resume document"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["tool_name"] == "resolve_document_processing_flow"
+    assert payload["result"]["document_type"] == "curriculum vitae"
+
+
+def test_docs_endpoint_serves_swagger_ui() -> None:
+    client = TestClient(create_app())
+
+    response = client.get("/docs")
+
+    assert response.status_code == 200
+    assert "SwaggerUIBundle" in response.text
+    assert "/openapi.json" in response.text
+
+
+def test_openapi_schema_documents_prompt_routes() -> None:
+    client = TestClient(create_app())
+
+    response = client.get("/openapi.json")
+
+    assert response.status_code == 200
+    schema = response.json()
+    assert schema["openapi"].startswith("3.")
+    assert "/api/prompts/route" in schema["paths"]
+    assert "/api/prompts/execute" in schema["paths"]
+    assert "PromptExecutionRequest" in schema["components"]["schemas"]


### PR DESCRIPTION
### Motivation

- Provide a lightweight HTTP API that allows a frontend to ask which backend tool should handle a prompt and optionally request execution. 
- Expose OpenAPI/Swagger documentation for easy testing and integration from the browser or a frontend. 
- Reuse existing Ollama client and backend/document tools to route and execute prompts programmatically.

### Description

- Add `src/http_api.py` which wires a Starlette app, serves `/`, `/docs`, and `/openapi.json`, and mounts the prompt router. 
- Implement `src/routers/prompt.py` to handle `GET /api/prompts/route` and `POST /api/prompts/execute` endpoints with request validation and error handling. 
- Implement `src/services/prompt_router.py` which contains routing heuristics in `route_prompt`, execution logic in `execute_prompt_tool`, and Pydantic models `PromptRoute`, `PromptExecutionRequest`, and `PromptExecutionResponse`. 
- Update `pyproject.toml` to add `starlette` and `uvicorn` dependencies and update `README.md` with local run instructions and examples; add unit tests in `tests/unit/test_prompt_router.py` that exercise routing, execution, and the HTTP endpoints.

### Testing

- Compiled sources with `python -m compileall src tests` to validate imports and syntax and it completed without errors. 
- Ran unit tests with `pytest -q`, executing `tests/unit/test_prompt_router.py`, and all tests passed. 
- The unit tests exercise `route_prompt`, `execute_prompt_tool`, and the HTTP endpoints using `starlette.testclient` and confirmed expected tool selection and response shapes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc419bd3208328ab1aa54dfb218a00)