### PR TITLE
fix: add HTTP dependency guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,17 @@ The HTTP API exposes prompt routing endpoints that a frontend can call before or
 
 ### Run the HTTP API locally
 
-Install the project dependencies, then start Uvicorn from the repository root:
+Install the project dependencies, then start Uvicorn from the repository root using the same Python environment:
 
 ```bash
 python -m pip install -e .
-uvicorn http_api:app --app-dir src --reload
+python -m uvicorn http_api:app --app-dir src --reload
+```
+
+Using `python -m uvicorn` helps avoid accidentally running a globally installed Uvicorn that cannot see this project's installed dependencies. If startup reports `Missing HTTP API dependency: starlette`, reinstall the project dependencies in the Python environment that launches Uvicorn:
+
+```bash
+python -m pip install -e .
 ```
 
 A route summary is available at `http://127.0.0.1:8000/`. Swagger UI is available at `http://127.0.0.1:8000/docs`, and the OpenAPI schema is available at `http://127.0.0.1:8000/openapi.json`.

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -1,107 +1,161 @@
 from __future__ import annotations
 
-from typing import Any
-
-from starlette.applications import Starlette
-from starlette.responses import HTMLResponse, JSONResponse, Response
-from starlette.routing import Route
+from importlib.util import find_spec
+from typing import Any, Iterable
 
 from config import SERVICE_NAME
-from routers.prompt import router as prompt_router
-from services.prompt_router import (
-    PromptExecutionRequest,
-    PromptExecutionResponse,
-    PromptRoute,
+
+HTTP_RUNTIME_DEPENDENCIES = ("fastmcp", "pydantic", "starlette")
+INSTALL_GUIDANCE = (
+    "Missing HTTP API dependency: {dependencies}. Install project dependencies with "
+    "`python -m pip install -e .`, then start the API with "
+    "`python -m uvicorn http_api:app --app-dir src --reload`."
 )
 
 
-def build_openapi_schema() -> dict[str, Any]:
-    return {
-        "openapi": "3.1.0",
-        "info": {
-            "title": SERVICE_NAME,
-            "version": "0.1.0",
-            "description": "HTTP API for frontend prompt routing and execution.",
-        },
-        "paths": {
-            "/api/prompts/route": {
-                "get": {
-                    "tags": ["prompts"],
-                    "summary": "Route a frontend prompt to the recommended tool.",
-                    "parameters": [
-                        {
-                            "name": "prompt",
-                            "in": "query",
-                            "required": True,
-                            "description": "Prompt message from the frontend.",
-                            "schema": {"type": "string", "minLength": 1},
-                        }
-                    ],
-                    "responses": {
-                        "200": {
-                            "description": "Recommended prompt route.",
-                            "content": {
-                                "application/json": {
-                                    "schema": {"$ref": "#/components/schemas/PromptRoute"}
-                                }
-                            },
-                        },
-                        "400": {"description": "Invalid prompt."},
-                    },
-                }
+class MissingDependencyASGI:
+    """Minimal ASGI app that returns actionable setup guidance."""
+
+    def __init__(self, missing_dependencies: Iterable[str]) -> None:
+        dependencies = tuple(missing_dependencies)
+        self.message = INSTALL_GUIDANCE.format(dependencies=", ".join(dependencies))
+
+    async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
+        if scope["type"] == "lifespan":
+            while True:
+                message = await receive()
+                if message["type"] == "lifespan.startup":
+                    await send({"type": "lifespan.startup.complete"})
+                elif message["type"] == "lifespan.shutdown":
+                    await send({"type": "lifespan.shutdown.complete"})
+                    return
+
+        body = (self.message + "\n").encode("utf-8")
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 503,
+                "headers": [
+                    (b"content-type", b"text/plain; charset=utf-8"),
+                    (b"content-length", str(len(body)).encode("ascii")),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": body})
+
+
+def get_missing_http_dependencies(
+    dependencies: Iterable[str] = HTTP_RUNTIME_DEPENDENCIES,
+) -> tuple[str, ...]:
+    return tuple(dependency for dependency in dependencies if find_spec(dependency) is None)
+
+
+_MISSING_DEPENDENCIES = get_missing_http_dependencies()
+
+if _MISSING_DEPENDENCIES:
+
+    def create_app() -> MissingDependencyASGI:
+        return MissingDependencyASGI(_MISSING_DEPENDENCIES)
+
+else:
+    from starlette.applications import Starlette
+    from starlette.responses import HTMLResponse, JSONResponse, Response
+    from starlette.routing import Route
+
+    from routers.prompt import router as prompt_router
+    from services.prompt_router import (
+        PromptExecutionRequest,
+        PromptExecutionResponse,
+        PromptRoute,
+    )
+
+    def build_openapi_schema() -> dict[str, Any]:
+        return {
+            "openapi": "3.1.0",
+            "info": {
+                "title": SERVICE_NAME,
+                "version": "0.1.0",
+                "description": "HTTP API for frontend prompt routing and execution.",
             },
-            "/api/prompts/execute": {
-                "post": {
-                    "tags": ["prompts"],
-                    "summary": "Execute a frontend prompt using the inferred or requested tool.",
-                    "requestBody": {
-                        "required": True,
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/PromptExecutionRequest"
-                                }
+            "paths": {
+                "/api/prompts/route": {
+                    "get": {
+                        "tags": ["prompts"],
+                        "summary": "Route a frontend prompt to the recommended tool.",
+                        "parameters": [
+                            {
+                                "name": "prompt",
+                                "in": "query",
+                                "required": True,
+                                "description": "Prompt message from the frontend.",
+                                "schema": {"type": "string", "minLength": 1},
                             }
+                        ],
+                        "responses": {
+                            "200": {
+                                "description": "Recommended prompt route.",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {"$ref": "#/components/schemas/PromptRoute"}
+                                    }
+                                },
+                            },
+                            "400": {"description": "Invalid prompt."},
                         },
-                    },
-                    "responses": {
-                        "200": {
-                            "description": "Prompt execution result.",
+                    }
+                },
+                "/api/prompts/execute": {
+                    "post": {
+                        "tags": ["prompts"],
+                        "summary": "Execute a frontend prompt using the inferred or requested tool.",
+                        "requestBody": {
+                            "required": True,
                             "content": {
                                 "application/json": {
                                     "schema": {
-                                        "$ref": "#/components/schemas/PromptExecutionResponse"
+                                        "$ref": "#/components/schemas/PromptExecutionRequest"
                                     }
                                 }
                             },
                         },
-                        "400": {"description": "Invalid prompt or tool arguments."},
-                        "422": {"description": "Invalid request body."},
-                    },
+                        "responses": {
+                            "200": {
+                                "description": "Prompt execution result.",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "$ref": "#/components/schemas/PromptExecutionResponse"
+                                        }
+                                    }
+                                },
+                            },
+                            "400": {"description": "Invalid prompt or tool arguments."},
+                            "422": {"description": "Invalid request body."},
+                        },
+                    }
+                },
+            },
+            "components": {
+                "schemas": {
+                    "PromptRoute": PromptRoute.model_json_schema(
+                        ref_template="#/components/schemas/{model}"
+                    ),
+                    "PromptExecutionRequest": PromptExecutionRequest.model_json_schema(
+                        ref_template="#/components/schemas/{model}"
+                    ),
+                    "PromptExecutionResponse": PromptExecutionResponse.model_json_schema(
+                        ref_template="#/components/schemas/{model}"
+                    ),
                 }
             },
-        },
-        "components": {
-            "schemas": {
-                "PromptRoute": PromptRoute.model_json_schema(ref_template="#/components/schemas/{model}"),
-                "PromptExecutionRequest": PromptExecutionRequest.model_json_schema(
-                    ref_template="#/components/schemas/{model}"
-                ),
-                "PromptExecutionResponse": PromptExecutionResponse.model_json_schema(
-                    ref_template="#/components/schemas/{model}"
-                ),
-            }
-        },
-    }
+        }
 
+    async def openapi_schema(_: object) -> Response:
+        return JSONResponse(build_openapi_schema())
 
-async def openapi_schema(_: object) -> Response:
-    return JSONResponse(build_openapi_schema())
-
-
-async def swagger_docs(_: object) -> Response:
-    return HTMLResponse(
-        """
+    async def swagger_docs(_: object) -> Response:
+        return HTMLResponse(
+            """
 <!doctype html>
 <html lang="en">
   <head>
@@ -123,32 +177,30 @@ async def swagger_docs(_: object) -> Response:
   </body>
 </html>
 """.strip()
-    )
+        )
 
+    async def api_hint(_: object) -> Response:
+        return JSONResponse(
+            {
+                "service": SERVICE_NAME,
+                "routes": [
+                    "GET /api/prompts/route?prompt=...",
+                    "POST /api/prompts/execute",
+                ],
+                "docs": "Open Swagger UI at /docs or fetch the OpenAPI schema at /openapi.json.",
+            }
+        )
 
-async def api_hint(_: object) -> Response:
-    return JSONResponse(
-        {
-            "service": SERVICE_NAME,
-            "routes": [
-                "GET /api/prompts/route?prompt=...",
-                "POST /api/prompts/execute",
+    def create_app() -> Starlette:
+        return Starlette(
+            debug=False,
+            routes=[
+                Route("/", api_hint, methods=["GET"]),
+                Route("/docs", swagger_docs, methods=["GET"]),
+                Route("/openapi.json", openapi_schema, methods=["GET"]),
+                *prompt_router.routes,
             ],
-            "docs": "Open Swagger UI at /docs or fetch the OpenAPI schema at /openapi.json.",
-        }
-    )
-
-
-def create_app() -> Starlette:
-    return Starlette(
-        debug=False,
-        routes=[
-            Route("/", api_hint, methods=["GET"]),
-            Route("/docs", swagger_docs, methods=["GET"]),
-            Route("/openapi.json", openapi_schema, methods=["GET"]),
-            *prompt_router.routes,
-        ],
-    )
+        )
 
 
 app = create_app()

--- a/tests/unit/test_prompt_router.py
+++ b/tests/unit/test_prompt_router.py
@@ -4,8 +4,8 @@ import sys
 from pathlib import Path
 
 import pytest
-from starlette.testclient import TestClient
 from fastmcp.exceptions import ToolError
+from starlette.testclient import TestClient
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
 from http_api import create_app
@@ -99,3 +99,31 @@ def test_openapi_schema_documents_prompt_routes() -> None:
     assert "/api/prompts/route" in schema["paths"]
     assert "/api/prompts/execute" in schema["paths"]
     assert "PromptExecutionRequest" in schema["components"]["schemas"]
+
+
+def test_http_dependency_checker_reports_missing_modules() -> None:
+    from http_api import get_missing_http_dependencies
+
+    assert get_missing_http_dependencies(("missing_smart_ide_http_dependency",)) == (
+        "missing_smart_ide_http_dependency",
+    )
+
+
+@pytest.mark.anyio
+async def test_missing_dependency_asgi_returns_setup_guidance() -> None:
+    from http_api import MissingDependencyASGI
+
+    sent_messages = []
+
+    async def receive() -> dict[str, str]:
+        return {"type": "http.request"}
+
+    async def send(message: dict[str, object]) -> None:
+        sent_messages.append(message)
+
+    app = MissingDependencyASGI(("starlette",))
+
+    await app({"type": "http"}, receive, send)
+
+    assert sent_messages[0]["status"] == 503
+    assert b"python -m pip install -e ." in sent_messages[1]["body"]


### PR DESCRIPTION
### Motivation
- Running a globally installed `uvicorn` can start the HTTP app in a Python environment that is missing project dependencies (for example, `starlette`), causing an opaque `ModuleNotFoundError` on startup. 
- Provide a clear, actionable fallback and documentation so local developers can quickly fix environment/setup issues instead of debugging an import crash.

### Description
- Added a runtime dependency preflight to `src/http_api.py` that checks for `fastmcp`, `pydantic`, and `starlette` and exposes `get_missing_http_dependencies` and `MissingDependencyASGI` as a minimal ASGI fallback returning install/run guidance. 
- Preserved the Starlette-based `create_app()` and full OpenAPI/Swagger behavior when dependencies are present. 
- Updated `README.md` to recommend running Uvicorn with `python -m uvicorn` from the same Python environment used to install the package and documented how to resolve the missing-dependency message. 
- Added unit tests in `tests/unit/test_prompt_router.py` to cover missing-dependency detection and the ASGI guidance response.

### Testing
- Ran `python -m compileall src tests` and compilation completed successfully. 
- Ran `pytest -q` and all unit tests passed (`22 passed`). 
- Launched the HTTP app with `python -m uvicorn http_api:app --app-dir src` in a short timeout and confirmed the server started and served the root endpoint as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc491e950c83288affe32eb811da8e)