### PR TITLE
feat: return ollama-only prompt responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ If you still get timeouts, try reducing prompt size by passing `max_chars` in `p
 
 ## Frontend prompt router API
 
-The HTTP API exposes a single POST prompt execution endpoint. The frontend sends the user message in the JSON body, and the service routes that message to the correct backend, document, health, or general chat tool before returning the tool result.
+The HTTP API exposes a single POST prompt execution endpoint. The frontend sends only the user message in the JSON body as `{"message":"prompt"}`. The service routes that message to the correct backend, document, health, or general chat tool, uses the inferred tool and related skills as Ollama context, and returns only the model answer as `{"response":"result of the prompt"}`.
 
 ### Run the HTTP API locally
 
@@ -150,7 +150,7 @@ curl -X POST "http://127.0.0.1:8000/api/prompts/execute" \
   -d '{"message":"Process an invoice document"}'
 ```
 
-The router chooses the tool from the message content. For compatibility with older callers, the body may use `prompt` instead of `message`, but clients should prefer `message`.
+The router chooses the tool from the message content. The request body must contain only the `message` field, and successful responses contain only the `response` field with the Ollama model result.
 
 Router validation is covered by unit tests and can be checked with:
 

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -71,13 +71,13 @@ else:
             "info": {
                 "title": SERVICE_NAME,
                 "version": "0.1.0",
-                "description": "HTTP API for frontend prompt routing and execution.",
+                "description": "HTTP API for frontend prompt routing with Ollama-only answers.",
             },
             "paths": {
                 "/api/prompts/execute": {
                     "post": {
                         "tags": ["prompts"],
-                        "summary": "Route and execute a frontend message using the inferred tool.",
+                        "summary": "Route a frontend message, enrich Ollama with the inferred tool, and return only the answer.",
                         "requestBody": {
                             "required": True,
                             "content": {
@@ -90,7 +90,7 @@ else:
                         },
                         "responses": {
                             "200": {
-                                "description": "Prompt execution result.",
+                                "description": "Ollama prompt response.",
                                 "content": {
                                     "application/json": {
                                         "schema": {

--- a/src/services/prompt_router.py
+++ b/src/services/prompt_router.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import json
 from typing import Any, Callable, Literal
 
 from fastmcp.exceptions import ToolError
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from clients.ollama import chat_with_ollama, ollama_health
 from tools.backend import (
@@ -32,26 +33,21 @@ class PromptRoute(BaseModel):
 class PromptExecutionRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    prompt: str = Field(
+    message: str = Field(
         ...,
         min_length=1,
-        validation_alias=AliasChoices("message", "prompt"),
-        description="Frontend message to route and execute with the inferred tool.",
+        description="Frontend message to route, enrich with the inferred tool, and answer with Ollama.",
     )
-    arguments: dict[str, Any] = Field(default_factory=dict)
 
 
 class PromptExecutionResponse(BaseModel):
-    prompt: str
-    tool_name: str
-    arguments: dict[str, Any]
-    result: Any
+    response: str
 
 
 def route_prompt(prompt: str) -> PromptRoute:
     text = prompt.strip().lower()
     if not text:
-        raise ToolError("prompt must not be empty.")
+        raise ToolError("message must not be empty.")
 
     if any(token in text for token in ("health", "status", "ollama", "reachable")):
         return PromptRoute(
@@ -126,17 +122,29 @@ def _required_argument(arguments: dict[str, Any], name: str) -> Any:
 async def execute_prompt_tool(
     request: PromptExecutionRequest,
 ) -> PromptExecutionResponse:
-    route = route_prompt(request.prompt)
-    tool_name = route.tool_name
-    arguments = dict(request.arguments)
+    route = route_prompt(request.message)
 
-    result = await _execute_tool(tool_name, request.prompt, arguments)
+    if route.tool_name == "send_prompt":
+        model_prompt = request.message
+    else:
+        tool_result = await _execute_tool(route.tool_name, request.message, {})
+        model_prompt = _build_model_prompt(request.message, route, tool_result)
 
-    return PromptExecutionResponse(
-        prompt=request.prompt,
-        tool_name=tool_name,
-        arguments=arguments,
-        result=result,
+    model_result = await chat_with_ollama(model_prompt)
+    return PromptExecutionResponse(response=model_result)
+
+
+def _build_model_prompt(prompt: str, route: PromptRoute, tool_result: Any) -> str:
+    tool_context = json.dumps(tool_result, indent=2, sort_keys=True)
+    return (
+        "Answer the user's prompt using the selected Smart IDE tool context. "
+        "Return only the final answer for the user; do not mention routing metadata unless it is directly useful.\n\n"
+        f"User prompt:\n{prompt}\n\n"
+        "Selected tool context:\n"
+        f"tool_name: {route.tool_name}\n"
+        f"category: {route.category}\n"
+        f"reason: {route.reason}\n"
+        f"result:\n{tool_context}"
     )
 
 

--- a/tests/unit/test_prompt_router.py
+++ b/tests/unit/test_prompt_router.py
@@ -27,31 +27,50 @@ def test_route_prompt_detects_document_intent() -> None:
 
 
 def test_route_prompt_rejects_blank_prompt() -> None:
-    with pytest.raises(ToolError, match="prompt must not be empty"):
+    with pytest.raises(ToolError, match="message must not be empty"):
         route_prompt("   ")
 
 
 @pytest.mark.anyio
-async def test_execute_prompt_tool_calls_inferred_backend_tool() -> None:
+async def test_execute_prompt_tool_calls_inferred_backend_tool(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_prompts: list[str] = []
+
+    async def fake_chat_with_ollama(prompt: str) -> str:
+        captured_prompts.append(prompt)
+        return "generated backend result"
+
+    monkeypatch.setattr("services.prompt_router.chat_with_ollama", fake_chat_with_ollama)
+
     response = await execute_prompt_tool(
-        PromptExecutionRequest(prompt="Build Node API with Express and TypeScript")
+        PromptExecutionRequest(message="Build Node API with Express and TypeScript")
     )
 
-    assert response.tool_name == "resolve_backend_skill"
-    assert response.result["stack"] == "node_express_typescript"
+    assert response.response == "generated backend result"
+    assert len(captured_prompts) == 1
+    assert "resolve_backend_skill" in captured_prompts[0]
+    assert "node_express_typescript" in captured_prompts[0]
+    assert "generate-express-typescript-backend" in captured_prompts[0]
 
 
 @pytest.mark.anyio
-async def test_execute_prompt_tool_accepts_frontend_message_alias() -> None:
+async def test_execute_prompt_tool_accepts_frontend_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_prompts: list[str] = []
+
+    async def fake_chat_with_ollama(prompt: str) -> str:
+        captured_prompts.append(prompt)
+        return "document result"
+
+    monkeypatch.setattr("services.prompt_router.chat_with_ollama", fake_chat_with_ollama)
+
     response = await execute_prompt_tool(
         PromptExecutionRequest.model_validate(
             {"message": "I need redaction support for a document"}
         )
     )
 
-    assert response.prompt == "I need redaction support for a document"
-    assert response.tool_name == "resolve_document_processing_flow"
-    assert response.result["flow"] == "generic_structured_extraction"
+    assert response.response == "document result"
+    assert "resolve_document_processing_flow" in captured_prompts[0]
+    assert "generic_structured_extraction" in captured_prompts[0]
 
 
 def test_get_prompt_route_endpoint_is_removed() -> None:
@@ -62,7 +81,11 @@ def test_get_prompt_route_endpoint_is_removed() -> None:
     assert response.status_code == 404
 
 
-def test_post_prompt_execute_endpoint() -> None:
+def test_post_prompt_execute_endpoint_returns_only_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_chat_with_ollama(_: str) -> str:
+        return "Process the resume with structured extraction."
+
+    monkeypatch.setattr("services.prompt_router.chat_with_ollama", fake_chat_with_ollama)
     client = TestClient(create_app())
 
     response = client.post(
@@ -71,9 +94,18 @@ def test_post_prompt_execute_endpoint() -> None:
     )
 
     assert response.status_code == 200
-    payload = response.json()
-    assert payload["tool_name"] == "resolve_document_processing_flow"
-    assert payload["result"]["document_type"] == "curriculum vitae"
+    assert response.json() == {"response": "Process the resume with structured extraction."}
+
+
+def test_post_prompt_execute_rejects_extra_fields() -> None:
+    client = TestClient(create_app())
+
+    response = client.post(
+        "/api/prompts/execute",
+        json={"message": "Process a resume document", "arguments": {}},
+    )
+
+    assert response.status_code == 422
 
 
 def test_docs_endpoint_serves_swagger_ui() -> None:
@@ -97,6 +129,7 @@ def test_openapi_schema_documents_prompt_routes() -> None:
     assert "/api/prompts/route" not in schema["paths"]
     assert "/api/prompts/execute" in schema["paths"]
     assert "PromptExecutionRequest" in schema["components"]["schemas"]
+    assert schema["components"]["schemas"]["PromptExecutionRequest"]["properties"].keys() == {"message"}
 
 
 def test_http_dependency_checker_reports_missing_modules() -> None:


### PR DESCRIPTION
### Motivation
- Simplify the HTTP contract so the frontend sends only a minimal prompt and receives only the model answer. 
- Keep tool routing and skill inference internal while exposing just the Ollama-produced response to clients.

### Description
- Changed the request/response models so `PromptExecutionRequest` accepts only `message` and `PromptExecutionResponse` returns only `response` (string). 
- Updated `execute_prompt_tool` to infer the tool from the message, call the inferred tool to gather context when needed, build an enriched prompt for Ollama, and return only the Ollama output. 
- Updated OpenAPI metadata and `README.md` to document the new `{"message":"..."}` request and `{"response":"..."}` response shape. 
- Adjusted router and unit tests to mock `chat_with_ollama`, assert the enriched model prompt includes inferred tool context, ensure extra request fields are rejected, and validate the response-only payload.

### Testing
- Ran `python -m compileall src tests` which succeeded. 
- Ran `pytest -q` which returned `23 passed`. 
- Verified the OpenAPI/schema and router behavior via unit tests that assert the request schema contains only `message` and responses contain only `response`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc573891cc8328a02cbd90cd48e359)