### PR TITLE
fix: clarify Ollama connectivity and status error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ LOG_FILE=logs/mcp.log LOG_MAX_BYTES=2097152 LOG_BACKUP_COUNT=10 python src/serve
 The `process_pdf` MCP tool sends extracted PDF text to Ollama. Large PDFs may take longer to complete.
 
 Environment variables:
+- `OLLAMA_URL` (default: `http://127.0.0.1:11434`)
+- `OLLAMA_MODEL` (default: `qwen2.5vl:7b`)
 - `OLLAMA_TIMEOUT_SECONDS` (default: `300`)
 
 Example:
@@ -109,6 +111,25 @@ OLLAMA_TIMEOUT_SECONDS=600 python src/server.py
 ```
 
 If you still get timeouts, try reducing prompt size by passing `max_chars` in `process_pdf`.
+
+If Ollama is running but the router still returns `Failed to reach Ollama at http://127.0.0.1:11434`, verify the URL from the environment where the API process runs:
+
+```bash
+curl http://127.0.0.1:11434/api/tags
+```
+
+When the API runs in Docker or WSL, `127.0.0.1` refers to that container or VM instead of the host machine. Set `OLLAMA_URL` to a reachable host address before starting the API, for example:
+
+```bash
+OLLAMA_URL=http://host.docker.internal:11434 python -m uvicorn http_api:app --app-dir src --reload
+```
+
+If Ollama is reachable but the configured model is missing, pull the model shown by the error or set `OLLAMA_MODEL` to one returned by `/api/tags`:
+
+```bash
+ollama pull qwen2.5vl:7b
+OLLAMA_MODEL=llama3.2 python -m uvicorn http_api:app --app-dir src --reload
+```
 
 ## Frontend prompt router API
 

--- a/src/clients/ollama.py
+++ b/src/clients/ollama.py
@@ -8,6 +8,32 @@ from fastmcp.exceptions import ToolError
 from config import OLLAMA_MODEL, OLLAMA_TIMEOUT_SECONDS, OLLAMA_URL
 
 
+def _short_response_body(response: httpx.Response, max_chars: int = 500) -> str:
+    body = response.text.strip()
+    if len(body) > max_chars:
+        return f"{body[:max_chars]}..."
+    return body
+
+
+def _ollama_status_error_message(response: httpx.Response) -> str:
+    body = _short_response_body(response)
+    detail = f" Ollama response: {body}" if body else ""
+    return (
+        f"Ollama at {OLLAMA_URL} returned HTTP {response.status_code} for model "
+        f"'{OLLAMA_MODEL}'.{detail} Ensure the model is available with "
+        f"'ollama pull {OLLAMA_MODEL}', or set OLLAMA_MODEL to an installed model."
+    )
+
+
+def _ollama_connection_error_message() -> str:
+    return (
+        f"Failed to reach Ollama at {OLLAMA_URL}. Ensure 'ollama serve' is running "
+        "where this service can reach it. If this API is running in Docker or WSL, "
+        "127.0.0.1 points at that environment, not your host; set OLLAMA_URL to the "
+        "reachable host address, for example http://host.docker.internal:11434."
+    )
+
+
 async def chat_with_ollama(prompt: str) -> str:
     if not prompt.strip():
         raise ToolError("Prompt must not be empty.")
@@ -28,10 +54,10 @@ async def chat_with_ollama(prompt: str) -> str:
             f"Ollama timed out after {OLLAMA_TIMEOUT_SECONDS:.0f}s. "
             "Try a smaller document, a faster model, or increase OLLAMA_TIMEOUT_SECONDS."
         ) from exc
+    except httpx.HTTPStatusError as exc:
+        raise ToolError(_ollama_status_error_message(exc.response)) from exc
     except httpx.HTTPError as exc:
-        raise ToolError(
-            f"Failed to reach Ollama at {OLLAMA_URL}. Ensure 'ollama serve' is running."
-        ) from exc
+        raise ToolError(_ollama_connection_error_message()) from exc
 
     message = data.get("message", {})
     content = message.get("content")
@@ -46,10 +72,10 @@ async def ollama_health() -> dict[str, Any]:
             tags_resp = await client.get(f"{OLLAMA_URL}/api/tags")
             tags_resp.raise_for_status()
             models = tags_resp.json().get("models", [])
+    except httpx.HTTPStatusError as exc:
+        raise ToolError(_ollama_status_error_message(exc.response)) from exc
     except httpx.HTTPError as exc:
-        raise ToolError(
-            f"Ollama is not reachable at {OLLAMA_URL}. Start it with: ollama serve"
-        ) from exc
+        raise ToolError(_ollama_connection_error_message()) from exc
 
     has_model = any(model.get("name") == OLLAMA_MODEL for model in models)
     return {

--- a/tests/unit/test_prompt_router.py
+++ b/tests/unit/test_prompt_router.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import httpx
 import pytest
 from fastmcp.exceptions import ToolError
 from starlette.testclient import TestClient
@@ -158,3 +159,30 @@ async def test_missing_dependency_asgi_returns_setup_guidance() -> None:
 
     assert sent_messages[0]["status"] == 503
     assert b"python -m pip install -e ." in sent_messages[1]["body"]
+
+
+def test_ollama_status_error_message_reports_model_setup() -> None:
+    from clients.ollama import _ollama_status_error_message
+
+    request = httpx.Request("POST", "http://127.0.0.1:11434/api/chat")
+    response = httpx.Response(
+        404,
+        request=request,
+        text='{"error":"model not found"}',
+    )
+
+    message = _ollama_status_error_message(response)
+
+    assert "returned HTTP 404" in message
+    assert "ollama pull" in message
+    assert "OLLAMA_MODEL" in message
+
+
+def test_ollama_connection_error_message_reports_container_url_guidance() -> None:
+    from clients.ollama import _ollama_connection_error_message
+
+    message = _ollama_connection_error_message()
+
+    assert "Failed to reach Ollama" in message
+    assert "Docker or WSL" in message
+    assert "OLLAMA_URL" in message


### PR DESCRIPTION
### Motivation
- Improve diagnostics when the router reports `Failed to reach Ollama` so users can distinguish network/connectivity issues from Ollama returning an HTTP error (e.g. missing model). 
- Provide actionable guidance for common environments where `127.0.0.1` is not the host (Docker / WSL). 
- Surface clearer next steps when the configured `OLLAMA_MODEL` is not available. 

### Description
- Added helper functions `_ollama_status_error_message`, `_ollama_connection_error_message`, and `_short_response_body` to `src/clients/ollama.py` to produce more informative error messages. 
- Updated `chat_with_ollama` and `ollama_health` to handle `httpx.HTTPStatusError` separately from generic `httpx.HTTPError` and raise the new, actionable messages. 
- Documented troubleshooting steps and new environment knobs (`OLLAMA_URL`, `OLLAMA_MODEL`) in `README.md` including `curl /api/tags` verification and `host.docker.internal` guidance. 
- Added unit tests in `tests/unit/test_prompt_router.py` to assert the new diagnostic messages for HTTP status failures and connection guidance. 

### Testing
- Ran `python -m compileall src tests` and compilation succeeded. 
- Ran `pytest -q` and the full test suite passed: `25 passed`. 
- New unit tests cover `_ollama_status_error_message` and `_ollama_connection_error_message` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01a5a1a4b08328a4f31c307bcbe483)