### PR TITLE
Add PDF upload endpoint with server-side extraction and Ollama integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ If you still get timeouts, try reducing prompt size by passing `max_chars` in `p
 
 ## Frontend prompt router API
 
-The HTTP API exposes a single POST prompt execution endpoint. The frontend sends only the user message in the JSON body as `{"message":"prompt"}`. The service routes that message to the correct backend, document, health, or general chat tool, uses the inferred tool and related skills as Ollama context, and returns only the model answer as `{"response":"result of the prompt"}`.
+The HTTP API exposes prompt execution plus PDF upload endpoints. For prompts, the frontend sends only the user message in the JSON body as `{"message":"prompt"}`; the service routes that message to the correct backend, document, health, or general chat tool, uses the inferred tool and related skills as Ollama context, and returns only the model answer as `{"response":"result of the prompt"}`. For PDFs, the frontend sends `multipart/form-data` with a PDF file and question, and receives an Ollama answer based on the uploaded document content.
 
 ### Run the HTTP API locally
 
@@ -123,7 +123,7 @@ python -m pip install -e .
 python -m uvicorn http_api:app --app-dir src --reload
 ```
 
-Using `python -m uvicorn` helps avoid accidentally running a globally installed Uvicorn that cannot see this project's installed dependencies. If startup reports `Missing HTTP API dependency: starlette`, reinstall the project dependencies in the Python environment that launches Uvicorn:
+Using `python -m uvicorn` helps avoid accidentally running a globally installed Uvicorn that cannot see this project's installed dependencies. If startup reports a missing HTTP API dependency such as `starlette` or `multipart`, reinstall the project dependencies in the Python environment that launches Uvicorn:
 
 ```bash
 python -m pip install -e .
@@ -136,9 +136,29 @@ A route summary is available at `http://127.0.0.1:8000/`. Swagger UI is availabl
 
 Yes. After starting Uvicorn, open `http://127.0.0.1:8000/docs` in your browser. You can expand:
 
+- `POST /api/documents/pdf`, click **Try it out**, choose a PDF file, enter a `question`, and execute it.
 - `POST /api/prompts/execute`, click **Try it out**, use a JSON body such as `{"message":"Process an invoice document"}`, and execute it.
 
 The Swagger page is backed by `http://127.0.0.1:8000/openapi.json`.
+
+### POST `/api/documents/pdf`
+
+Use this endpoint when the frontend needs to upload a PDF with `multipart/form-data` and ask a question about the document content. The API extracts text from the PDF first, then sends that extracted text to Ollama. Ollama does **not** read the raw PDF binary directly. Scanned or image-only PDFs need OCR before this endpoint can answer questions from their content.
+
+The form fields are:
+
+- `file`: required PDF upload.
+- `question`: required question to answer from the PDF content.
+- `max_chars`: optional maximum extracted characters to include in the model prompt; defaults to `30000`.
+
+```bash
+curl -X POST "http://127.0.0.1:8000/api/documents/pdf" \
+  -F "file=@/path/to/document.pdf;type=application/pdf" \
+  -F "question=Summarize this document" \
+  -F "max_chars=30000"
+```
+
+Successful responses contain only the Ollama answer as `{"response":"result based on the uploaded PDF"}`.
 
 ### POST `/api/prompts/execute`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.10"
 dependencies = [
   "fastmcp>=2.4,<4",
   "httpx>=0.27.0",
+  "python-multipart>=0.0.9,<1",
   "starlette>=0.37.0,<2",
   "uvicorn[standard]>=0.30.0,<1",
 ]

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -5,7 +5,7 @@ from typing import Any, Iterable
 
 from config import SERVICE_NAME
 
-HTTP_RUNTIME_DEPENDENCIES = ("fastmcp", "pydantic", "starlette")
+HTTP_RUNTIME_DEPENDENCIES = ("fastmcp", "multipart", "pydantic", "starlette")
 INSTALL_GUIDANCE = (
     "Missing HTTP API dependency: {dependencies}. Install project dependencies with "
     "`python -m pip install -e .`, then start the API with "
@@ -47,7 +47,9 @@ class MissingDependencyASGI:
 def get_missing_http_dependencies(
     dependencies: Iterable[str] = HTTP_RUNTIME_DEPENDENCIES,
 ) -> tuple[str, ...]:
-    return tuple(dependency for dependency in dependencies if find_spec(dependency) is None)
+    return tuple(
+        dependency for dependency in dependencies if find_spec(dependency) is None
+    )
 
 
 _MISSING_DEPENDENCIES = get_missing_http_dependencies()
@@ -62,7 +64,9 @@ else:
     from starlette.responses import HTMLResponse, JSONResponse, Response
     from starlette.routing import Route
 
+    from routers.document import router as document_router
     from routers.prompt import router as prompt_router
+    from services.document_upload import PdfUploadResponse
     from services.prompt_router import PromptExecutionRequest, PromptExecutionResponse
 
     def build_openapi_schema() -> dict[str, Any]:
@@ -74,6 +78,58 @@ else:
                 "description": "HTTP API for frontend prompt routing with Ollama-only answers.",
             },
             "paths": {
+                "/api/documents/pdf": {
+                    "post": {
+                        "tags": ["documents"],
+                        "summary": "Upload a PDF with multipart form data and answer a question using extracted text.",
+                        "description": "The API extracts PDF text server-side, then sends that extracted text to Ollama. Ollama does not receive or parse raw PDF bytes.",
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "multipart/form-data": {
+                                    "schema": {
+                                        "type": "object",
+                                        "required": ["file", "question"],
+                                        "properties": {
+                                            "file": {
+                                                "type": "string",
+                                                "format": "binary",
+                                                "description": "PDF file to process.",
+                                            },
+                                            "question": {
+                                                "type": "string",
+                                                "minLength": 1,
+                                                "description": "Question to answer using the uploaded PDF content.",
+                                            },
+                                            "max_chars": {
+                                                "type": "integer",
+                                                "default": 30000,
+                                                "minimum": 1,
+                                                "description": "Maximum extracted PDF characters to include in the model prompt.",
+                                            },
+                                        },
+                                    }
+                                }
+                            },
+                        },
+                        "responses": {
+                            "200": {
+                                "description": "Ollama answer based on the uploaded PDF.",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "$ref": "#/components/schemas/PdfUploadResponse"
+                                        }
+                                    }
+                                },
+                            },
+                            "400": {
+                                "description": "Invalid upload, PDF extraction failure, or Ollama error."
+                            },
+                            "422": {"description": "Invalid form fields."},
+                        },
+                    }
+                },
                 "/api/prompts/execute": {
                     "post": {
                         "tags": ["prompts"],
@@ -107,6 +163,9 @@ else:
             },
             "components": {
                 "schemas": {
+                    "PdfUploadResponse": PdfUploadResponse.model_json_schema(
+                        ref_template="#/components/schemas/{model}"
+                    ),
                     "PromptExecutionRequest": PromptExecutionRequest.model_json_schema(
                         ref_template="#/components/schemas/{model}"
                     ),
@@ -121,8 +180,7 @@ else:
         return JSONResponse(build_openapi_schema())
 
     async def swagger_docs(_: object) -> Response:
-        return HTMLResponse(
-            """
+        return HTMLResponse("""
 <!doctype html>
 <html lang="en">
   <head>
@@ -143,14 +201,14 @@ else:
     </script>
   </body>
 </html>
-""".strip()
-        )
+""".strip())
 
     async def api_hint(_: object) -> Response:
         return JSONResponse(
             {
                 "service": SERVICE_NAME,
                 "routes": [
+                    "POST /api/documents/pdf",
                     "POST /api/prompts/execute",
                 ],
                 "docs": "Open Swagger UI at /docs or fetch the OpenAPI schema at /openapi.json.",
@@ -164,6 +222,7 @@ else:
                 Route("/", api_hint, methods=["GET"]),
                 Route("/docs", swagger_docs, methods=["GET"]),
                 Route("/openapi.json", openapi_schema, methods=["GET"]),
+                *document_router.routes,
                 *prompt_router.routes,
             ],
         )

--- a/src/routers/document.py
+++ b/src/routers/document.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from fastmcp.exceptions import ToolError
+from pydantic import ValidationError
+from starlette.datastructures import UploadFile
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import Route, Router
+from starlette.status import HTTP_400_BAD_REQUEST
+
+from services.document_upload import PdfUploadRequest, process_pdf_upload
+
+
+async def post_pdf_upload(request: Request) -> Response:
+    try:
+        form = await request.form()
+        upload = form.get("file")
+        if not isinstance(upload, UploadFile):
+            raise ToolError(
+                "multipart field 'file' is required and must contain a PDF upload."
+            )
+
+        upload_request = PdfUploadRequest.model_validate(
+            {
+                "question": form.get("question"),
+                "max_chars": form.get("max_chars", 30000),
+            }
+        )
+        response = await process_pdf_upload(upload, upload_request)
+    except ValidationError as exc:
+        return JSONResponse(
+            {"detail": exc.errors()},
+            status_code=422,
+        )
+    except ToolError as exc:
+        return JSONResponse({"detail": str(exc)}, status_code=HTTP_400_BAD_REQUEST)
+
+    return JSONResponse(response.model_dump())
+
+
+router = Router(routes=[Route("/api/documents/pdf", post_pdf_upload, methods=["POST"])])

--- a/src/services/document_upload.py
+++ b/src/services/document_upload.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from fastmcp.exceptions import ToolError
+from pydantic import BaseModel, ConfigDict, Field
+from starlette.datastructures import UploadFile
+
+from clients.ollama import chat_with_ollama
+from tools.document import (
+    build_document_prompt,
+    extract_pdf_text,
+    truncate_document_text,
+)
+
+
+class PdfUploadRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    question: str = Field(
+        ...,
+        min_length=1,
+        description="Question to answer using the uploaded PDF content.",
+    )
+    max_chars: int = Field(
+        30000,
+        gt=0,
+        description="Maximum extracted PDF characters to include in the Ollama prompt.",
+    )
+
+
+class PdfUploadResponse(BaseModel):
+    response: str
+
+
+async def process_pdf_upload(
+    upload: UploadFile,
+    request: PdfUploadRequest,
+) -> PdfUploadResponse:
+    """Extract PDF text server-side, then ask Ollama about that text.
+
+    Ollama does not receive or parse the raw PDF binary. Image-only or scanned PDFs
+    without an extractable text layer require OCR before this endpoint can answer.
+    """
+    _validate_pdf_upload(upload)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir) / "upload.pdf"
+        await _write_upload_to_file(upload, temp_path)
+        document_text = extract_pdf_text(str(temp_path))
+
+    truncated_text = truncate_document_text(document_text, max_chars=request.max_chars)
+    prompt = build_document_prompt(truncated_text, request.question)
+    model_result = await chat_with_ollama(prompt)
+    return PdfUploadResponse(response=model_result)
+
+
+def _validate_pdf_upload(upload: UploadFile) -> None:
+    filename = upload.filename or ""
+    content_type = upload.content_type or ""
+    if not filename.lower().endswith(".pdf"):
+        raise ToolError("Uploaded file must use a .pdf filename.")
+    if content_type and content_type not in ("application/pdf", "application/x-pdf"):
+        raise ToolError(
+            f"Uploaded file must be a PDF, got content type: {content_type}"
+        )
+
+
+async def _write_upload_to_file(upload: UploadFile, destination: Path) -> None:
+    bytes_written = 0
+    with destination.open("wb") as file_obj:
+        while chunk := await upload.read(1024 * 1024):
+            bytes_written += len(chunk)
+            file_obj.write(chunk)
+
+    await upload.close()
+    if bytes_written == 0:
+        raise ToolError("Uploaded PDF is empty.")

--- a/tests/unit/test_document_upload.py
+++ b/tests/unit/test_document_upload.py
@@ -1,0 +1,117 @@
+import asyncio
+from io import BytesIO
+
+import pytest
+from fastmcp.exceptions import ToolError
+from starlette.datastructures import Headers, UploadFile
+
+from services import document_upload
+from services.document_upload import PdfUploadRequest, process_pdf_upload
+
+
+def make_upload(
+    filename: str = "sample.pdf",
+    content_type: str = "application/pdf",
+    content: bytes = b"%PDF-1.7",
+) -> UploadFile:
+    return UploadFile(
+        BytesIO(content),
+        filename=filename,
+        headers=Headers({"content-type": content_type}),
+    )
+
+
+def test_process_pdf_upload_extracts_uploaded_pdf_and_calls_ollama(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, str] = {}
+
+    def fake_extract_pdf_text(file_path: str) -> str:
+        captured["file_path"] = file_path
+        return "Uploaded PDF text"
+
+    async def fake_chat_with_ollama(prompt: str) -> str:
+        captured["prompt"] = prompt
+        return "PDF answer"
+
+    monkeypatch.setattr(document_upload, "extract_pdf_text", fake_extract_pdf_text)
+    monkeypatch.setattr(document_upload, "chat_with_ollama", fake_chat_with_ollama)
+
+    response = asyncio.run(
+        process_pdf_upload(
+            make_upload(),
+            PdfUploadRequest(question="What is this document?", max_chars=1000),
+        )
+    )
+
+    assert response.response == "PDF answer"
+    assert captured["file_path"].endswith(".pdf")
+    assert "Uploaded PDF text" in captured["prompt"]
+    assert "What is this document?" in captured["prompt"]
+
+
+def test_process_pdf_upload_rejects_non_pdf_filename() -> None:
+    with pytest.raises(ToolError, match=".pdf filename"):
+        asyncio.run(
+            process_pdf_upload(
+                make_upload(filename="notes.txt", content_type="text/plain"),
+                PdfUploadRequest(question="What is this?"),
+            )
+        )
+
+
+def test_process_pdf_upload_rejects_empty_upload() -> None:
+    with pytest.raises(ToolError, match="empty"):
+        asyncio.run(
+            process_pdf_upload(
+                make_upload(content=b""),
+                PdfUploadRequest(question="What is this?"),
+            )
+        )
+
+
+def test_pdf_upload_endpoint_accepts_multipart_form_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from starlette.applications import Starlette
+    from starlette.testclient import TestClient
+
+    from routers import document as document_router
+    from services.document_upload import PdfUploadResponse
+
+    captured: dict[str, object] = {}
+
+    async def fake_process_pdf_upload(
+        upload: UploadFile,
+        request: PdfUploadRequest,
+    ) -> PdfUploadResponse:
+        captured["filename"] = upload.filename
+        captured["question"] = request.question
+        captured["max_chars"] = request.max_chars
+        return PdfUploadResponse(response="endpoint answer")
+
+    monkeypatch.setattr(document_router, "process_pdf_upload", fake_process_pdf_upload)
+    client = TestClient(Starlette(routes=document_router.router.routes))
+
+    response = client.post(
+        "/api/documents/pdf",
+        data={"question": "Summarize", "max_chars": "123"},
+        files={"file": ("sample.pdf", b"%PDF-1.7", "application/pdf")},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"response": "endpoint answer"}
+    assert captured == {
+        "filename": "sample.pdf",
+        "question": "Summarize",
+        "max_chars": 123,
+    }
+
+
+def test_pdf_upload_openapi_documents_text_extraction_before_ollama() -> None:
+    from http_api import build_openapi_schema
+
+    operation = build_openapi_schema()["paths"]["/api/documents/pdf"]["post"]
+
+    assert "extracted text" in operation["summary"]
+    assert "Ollama does not receive or parse raw PDF bytes" in operation["description"]


### PR DESCRIPTION
### Motivation

- Provide a frontend-accessible endpoint to upload a PDF, extract its text server-side, and ask Ollama questions about the extracted content while ensuring Ollama never receives raw PDF bytes.
- Ensure the HTTP API advertises the new capability in OpenAPI/Swagger and that multipart uploads are supported at runtime.

### Description

- Added a new document router at `src/routers/document.py` exposing `POST /api/documents/pdf` to accept `multipart/form-data` uploads and delegate processing to the service layer.
- Implemented `src/services/document_upload.py` with `PdfUploadRequest`/`PdfUploadResponse`, server-side PDF validation, temporary file writing, text extraction via `extract_pdf_text`, truncation, prompt construction with `build_document_prompt`, and calling `chat_with_ollama` for the model answer.
- Updated `src/http_api.py` to require `multipart` at runtime, include the new router and OpenAPI schema for the PDF upload operation, and list the new route in the API hint; also adjusted Swagger HTML generation formatting.
- Added `python-multipart` to `pyproject.toml` and updated `README.md` with usage examples and cURL instructions for `POST /api/documents/pdf`.
- Added unit tests in `tests/unit/test_document_upload.py` that cover processing, validation failures, endpoint behavior, and OpenAPI documentation content.

### Testing

- Ran `python -m compileall src tests` to validate import-time correctness and bytecode compilation, which completed successfully.
- Ran `pytest -q` to execute unit tests including `tests/unit/test_document_upload.py`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0418af39c88328a05ea97e336a6f80)