### PR TITLE
feat: add insurance document reader agent and insurance-focused document skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,19 @@ pytest -q
 
 Coverage includes:
 - intent routing for Java/Spring, Node/Express/TypeScript, and Python/FastAPI;
+- insurance document-reading flow routing and agent/skill exposure;
 - invalid stack intent handling;
 - blueprint list contains expected generation skills.
+
+## Insurance document-reading agent
+
+Document-processing blueprints include an `insurance-document-reader-agent` for reading insurance policies and related claim documents. Insurance prompts such as “read this insurance policy,” “summarize coverage,” “check exclusions,” or “extract claim requirements” route to the `insurance_policy_reading` flow and use these skills:
+
+- `insurance-policy-reading`
+- `coverage-exclusions-analysis`
+- `claims-requirements-extraction`
+
+The insurance agent summarizes policy facts, coverage, exclusions, deadlines, and claim obligations from supplied document text, while flagging missing pages, ambiguous clauses, and items needing licensed or legal review.
 
 ## Rotative logs for MCP tools
 

--- a/docs/mcp-skills-agents-tools.md
+++ b/docs/mcp-skills-agents-tools.md
@@ -122,3 +122,34 @@ For document-heavy workflows (invoices, CVs, resumes, forms), add the following 
 - `resolve_document_processing_flow(user_request)`: routes request to invoice, CV, or generic extraction flow.
 
 - `list_platform_blueprints`: returns both backend and document-processing blueprint catalogs in one response.
+
+## 6) Insurance document-reading extension
+
+Insurance policy requests are handled as document-processing workflows with a dedicated **insurance-document-reader-agent**.
+
+### Insurance skills
+
+1. **insurance-policy-reading**
+   - Reads policy declarations, schedules, endorsements, certificates, renewal notices, and claim forms.
+   - Extracts insurer, policyholder, policy number, effective dates, limits, deductibles, premiums, exclusions, endorsements, cancellation, and renewal terms.
+
+2. **coverage-exclusions-analysis**
+   - Maps user scenarios to coverage grants, limits, exclusions, exceptions, endorsements, and unknowns.
+   - Flags ambiguous clauses and recommends human review rather than making binding coverage determinations.
+
+3. **claims-requirements-extraction**
+   - Extracts notice duties, proof-of-loss requirements, evidence checklists, deadlines, contacts, and escalation paths.
+   - Produces actionable claim-preparation checklists while protecting sensitive claim details.
+
+### Insurance agent
+
+**insurance-document-reader-agent**
+- Input: extracted policy text, insurance document type, user question, optional scenario/claim details.
+- Output: coverage summary, exclusions, claim requirements, missing-information prompts, confidence warnings, and human-review recommendations.
+- Uses: `insurance-policy-reading`, `coverage-exclusions-analysis`, `claims-requirements-extraction`, `document-validation`, and `pii-redaction`.
+
+### Routing examples
+
+- “Read this insurance policy and summarize coverage” -> `insurance_policy_reading`.
+- “Is water damage excluded in this policy?” -> `insurance_policy_reading` with `coverage-exclusions-analysis`.
+- “What documents do I need for this claim?” -> `insurance_policy_reading` with `claims-requirements-extraction`.

--- a/skills/README.md
+++ b/skills/README.md
@@ -14,9 +14,21 @@ It also contains reusable document-processing skills:
 - `pii-redaction`
 - `document-validation`
 - `fraud-signals-detection`
+- `insurance-policy-reading`
+- `coverage-exclusions-analysis`
+- `claims-requirements-extraction`
 - `document-processing-observability`
 
 ## Intent routing examples
 - "Create a backend in Java" -> `generate-spring-boot-java-backend`
 - "Create a Node backend with Express and TS" -> `generate-express-typescript-backend`
 - "Create a backend in Python using FastAPI" -> `generate-fastapi-python-backend`
+
+
+## Insurance document reading
+
+Insurance-related prompts such as “read this insurance policy,” “summarize coverage,” or “extract claim requirements” should route to the document-processing blueprint and use the `insurance-document-reader-agent` with these skills:
+
+- `insurance-policy-reading` for policy declarations, endorsements, limits, deductibles, exclusions, and renewal/cancellation terms.
+- `coverage-exclusions-analysis` for mapping user scenarios to coverage grants, limits, exclusions, exceptions, and ambiguous clauses.
+- `claims-requirements-extraction` for notice duties, proof-of-loss requirements, evidence checklists, deadlines, and escalation paths.

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -27,3 +27,14 @@ This folder contains reusable backend-generation skills for MCP intent routing.
 - Keep skills focused on production-oriented backend scaffolding.
 - Include architecture, security, observability, and testing guidance.
 - Keep stack-specific conventions explicit and actionable.
+
+
+## Document-processing skills
+
+Insurance document requests should use the `insurance-document-reader-agent` alongside:
+
+- `insurance-policy-reading` when the user asks to read, summarize, or extract facts from an insurance policy.
+- `coverage-exclusions-analysis` when the user asks whether a scenario appears covered, excluded, conditional, or unclear from the supplied policy text.
+- `claims-requirements-extraction` when the user asks what is needed to submit or prepare a claim.
+
+These skills are document-reading support only. They should avoid legal or licensed-insurance advice and should flag ambiguous or missing policy text for human review.

--- a/skills/claims-requirements-extraction.md
+++ b/skills/claims-requirements-extraction.md
@@ -1,0 +1,28 @@
+# claims-requirements-extraction
+
+## Purpose
+Guide the **claims-requirements-extraction** capability for turning insurance policy claim conditions into actionable intake and submission checklists.
+
+## Inputs
+- Insurance policy text or extracted structured facts
+- Claim scenario, loss date, policy period, and claimant context when available
+- Compliance constraints for privacy, jurisdiction, or workflow integration
+
+## Outputs
+- Claim notice and submission checklist with required documents, forms, evidence, dates, and recipients
+- Deadlines, waiting periods, proof-of-loss requirements, cooperation duties, and escalation paths
+- Missing-information prompts and field-level validation warnings
+- Structured handoff payload for claims intake or case-management systems
+
+## Workflow
+1. Locate claim notice, proof-of-loss, cooperation, appraisal, dispute, and limitation clauses.
+2. Extract deadlines relative to incident date, discovery date, notice date, or policy effective dates.
+3. Identify required evidence, forms, contacts, delivery channels, and escalation steps.
+4. Validate whether key scenario facts are present and ask for missing facts explicitly.
+5. Generate a concise checklist plus machine-readable fields for downstream workflows.
+
+## Operational guidance
+- Do not log sensitive claim details unless explicitly required and approved by policy.
+- Clearly mark deadlines that are inferred from relative wording rather than explicit dates.
+- Highlight incomplete policy text, unreadable OCR regions, and missing endorsements.
+- Recommend human review for missed-deadline risk, denial-risk language, or complex disputes.

--- a/skills/coverage-exclusions-analysis.md
+++ b/skills/coverage-exclusions-analysis.md
@@ -1,0 +1,28 @@
+# coverage-exclusions-analysis
+
+## Purpose
+Guide the **coverage-exclusions-analysis** capability for comparing claimed scenarios against policy coverage grants, limits, exclusions, and endorsements.
+
+## Inputs
+- Extracted insurance policy facts and clause text
+- User scenario or claim question
+- Coverage profile (line of business, jurisdiction, product type, compliance mode)
+
+## Outputs
+- Scenario-to-coverage mapping with covered, excluded, conditional, and unknown statuses
+- Limits, sublimits, deductibles, waiting periods, and endorsement impacts
+- Exclusion and exception summary with confidence and source locations when available
+- Human-review warnings for ambiguous, conflicting, or jurisdiction-sensitive clauses
+
+## Workflow
+1. Normalize the user scenario into events, parties, property, dates, losses, and requested benefits.
+2. Match scenario elements to coverage grants and declarations-page limits.
+3. Check exclusions, exceptions to exclusions, endorsements, riders, and conditions precedent.
+4. Produce a decision-support matrix without making binding coverage determinations.
+5. Surface gaps, conflicts, missing facts, and recommended next questions.
+
+## Operational guidance
+- Treat the policy text as the source of truth and avoid external assumptions about coverage.
+- Separate factual extraction from interpretation and recommendation.
+- Preserve confidence scores per clause and per scenario mapping.
+- Include clear disclaimers when the answer requires insurer, broker, legal, or licensed professional review.

--- a/skills/insurance-policy-reading.md
+++ b/skills/insurance-policy-reading.md
@@ -1,0 +1,28 @@
+# insurance-policy-reading
+
+## Purpose
+Guide the **insurance-policy-reading** capability for insurance documents such as policy declarations, schedules, endorsements, certificates of insurance, claim forms, and renewal notices.
+
+## Inputs
+- Document source (path/URI or extracted text)
+- Insurance context (line of business, jurisdiction, policyholder question, compliance constraints)
+- Optional policy profile with expected products, coverages, and claim scenario
+
+## Outputs
+- Plain-language coverage summary with citations to extracted clauses when available
+- Structured policy facts: insurer, policyholder, policy number, effective dates, limits, deductibles, premiums, endorsements, exclusions, and cancellation/renewal terms
+- Claim-readiness notes: notice requirements, evidence checklist, deadlines, contacts, and escalation paths
+- Confidence indicators, ambiguities, missing pages/schedules, and recommended human-review items
+
+## Workflow
+1. Classify the insurance document subtype and line of business before extraction.
+2. Extract declarations-page facts first, then reconcile schedules, riders, and endorsements.
+3. Identify covered events, limits, sublimits, deductibles, exclusions, waiting periods, and conditions precedent.
+4. Map claim obligations to a checklist with dates, evidence requirements, contacts, and unresolved dependencies.
+5. Flag contradictions, ambiguous wording, missing attachments, low-confidence OCR spans, and clauses requiring licensed insurance/legal review.
+
+## Operational guidance
+- Do not present coverage determinations as legal advice; frame results as document-reading support.
+- Preserve sensitive personal, health, financial, and claims data boundaries in logs and outputs.
+- Keep extracted clause references and field confidence attached to each coverage or claim finding.
+- Prefer explicit “not found in provided document” messages over inference when the policy text is incomplete.

--- a/src/domain/blueprints.py
+++ b/src/domain/blueprints.py
@@ -92,12 +92,16 @@ DOCUMENT_BLUEPRINT: dict[str, list[str]] = {
         "pii-redaction",
         "document-validation",
         "fraud-signals-detection",
+        "insurance-policy-reading",
+        "coverage-exclusions-analysis",
+        "claims-requirements-extraction",
         "document-processing-observability",
     ],
     "agents": [
         "document-intake-agent",
         "document-extraction-agent",
         "document-validation-agent",
+        "insurance-document-reader-agent",
         "document-review-agent",
     ],
     "tools": [

--- a/src/services/prompt_router.py
+++ b/src/services/prompt_router.py
@@ -71,6 +71,10 @@ def route_prompt(prompt: str) -> PromptRoute:
             "pii",
             "extract fields",
             "validate document",
+            "insurance",
+            "policy",
+            "coverage",
+            "claim",
         )
     ):
         return PromptRoute(

--- a/src/tools/backend.py
+++ b/src/tools/backend.py
@@ -94,6 +94,12 @@ def generate_document_skill_set_tool(document_type: str, compliance_mode: str = 
             "Normalize date ranges and durations",
             "Flag missing chronology and overlapping periods",
         ],
+        "insurance policy": [
+            "Identify policyholder, insurer, policy number, effective dates, and renewal terms",
+            "Extract coverage limits, deductibles, endorsements, exclusions, and waiting periods",
+            "Summarize claim notice duties, required evidence, deadlines, and escalation paths",
+            "Flag ambiguous clauses, missing schedules, and conflicts between declarations and endorsements",
+        ],
     }
     checklist = checklists.get(doc_type, [
         "Classify document layout and language",
@@ -117,16 +123,27 @@ def generate_document_agent_plan_tool(document_type: str, objective: str, constr
         raise ToolError("document_type must not be empty.")
 
     agents = DOCUMENT_BLUEPRINT["agents"]
+    plan = [
+        {"step": 1, "agent": agents[0], "task": "Classify document and choose extraction pipeline"},
+        {"step": 2, "agent": agents[1], "task": "Run OCR + structured field extraction with confidence scores"},
+        {"step": 3, "agent": agents[2], "task": "Validate business rules, required fields, and anomaly checks"},
+    ]
+    if doc_type in {"insurance", "insurance policy", "policy"}:
+        plan.append({
+            "step": 4,
+            "agent": "insurance-document-reader-agent",
+            "task": "Read policy language, summarize coverage, exclusions, limits, deductibles, and claim obligations",
+        })
+    plan.append({
+        "step": len(plan) + 1,
+        "agent": "document-review-agent",
+        "task": "Generate review summary and remediation recommendations",
+    })
     return {
         "document_type": doc_type,
         "objective": objective,
         "constraints": constraints,
-        "plan": [
-            {"step": 1, "agent": agents[0], "task": "Classify document and choose extraction pipeline"},
-            {"step": 2, "agent": agents[1], "task": "Run OCR + structured field extraction with confidence scores"},
-            {"step": 3, "agent": agents[2], "task": "Validate business rules, required fields, and anomaly checks"},
-            {"step": 4, "agent": agents[3], "task": "Generate review summary and remediation recommendations"},
-        ],
+        "plan": plan,
     }
 
 
@@ -136,6 +153,11 @@ def generate_document_tool_spec_tool(capability: str) -> dict[str, Any]:
         raise ToolError("capability must not be empty.")
 
     specs = {
+        "insurance": {
+            "name": "read_insurance_policy",
+            "args": ["document_uri", "policy_profile", "jurisdiction"],
+            "returns": ["coverage_summary", "exclusions", "claim_requirements", "warnings"],
+        },
         "extract": {
             "name": "extract_document_fields",
             "args": ["document_uri", "schema"],
@@ -174,6 +196,12 @@ def resolve_document_processing_flow_tool(user_request: str) -> dict[str, str]:
             "document_type": "invoice",
             "flow": "ap_invoice_automation",
             "reason": "Detected invoice processing intent.",
+        }
+    if "insurance" in text or "policy" in text or "coverage" in text or "claim" in text:
+        return {
+            "document_type": "insurance policy",
+            "flow": "insurance_policy_reading",
+            "reason": "Detected insurance policy reading intent.",
         }
     if "cv" in text or "resume" in text or "curriculum vitae" in text:
         return {

--- a/tests/unit/test_backend_skills.py
+++ b/tests/unit/test_backend_skills.py
@@ -7,7 +7,15 @@ import pytest
 from fastmcp.exceptions import ToolError
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
-from server import list_backend_blueprints, list_platform_blueprints, resolve_backend_skill
+from server import (
+    generate_document_agent_plan,
+    generate_document_skill_set,
+    generate_document_tool_spec,
+    list_backend_blueprints,
+    list_platform_blueprints,
+    resolve_backend_skill,
+    resolve_document_processing_flow,
+)
 
 
 @pytest.mark.anyio
@@ -52,3 +60,56 @@ async def test_list_platform_blueprints_contains_backend_and_document() -> None:
     assert "document_processing" in data
     assert "python_fastapi" in data["backend"]
     assert "ocr-extraction" in data["document_processing"]["skills"]
+
+
+@pytest.mark.anyio
+async def test_list_platform_blueprints_contains_insurance_agent_and_skills() -> None:
+    data = await list_platform_blueprints()
+
+    document_processing = data["document_processing"]
+
+    assert "insurance-document-reader-agent" in document_processing["agents"]
+    assert "insurance-policy-reading" in document_processing["skills"]
+    assert "coverage-exclusions-analysis" in document_processing["skills"]
+    assert "claims-requirements-extraction" in document_processing["skills"]
+
+
+@pytest.mark.anyio
+async def test_resolve_document_processing_flow_detects_insurance_policy() -> None:
+    result = await resolve_document_processing_flow(
+        "Read this insurance policy and summarize coverage exclusions"
+    )
+
+    assert result["document_type"] == "insurance policy"
+    assert result["flow"] == "insurance_policy_reading"
+
+
+@pytest.mark.anyio
+async def test_generate_document_skill_set_for_insurance_policy() -> None:
+    result = await generate_document_skill_set("insurance policy")
+
+    assert result["document_type"] == "insurance policy"
+    assert "insurance-policy-reading" in result["priority_skills"]
+    assert any("coverage limits" in item for item in result["checklist"])
+
+
+@pytest.mark.anyio
+async def test_generate_document_agent_plan_uses_insurance_reader_agent() -> None:
+    result = await generate_document_agent_plan(
+        "insurance policy",
+        "Summarize covered events and claim requirements",
+    )
+
+    agents = [step["agent"] for step in result["plan"]]
+
+    assert "insurance-document-reader-agent" in agents
+    assert agents[-1] == "document-review-agent"
+
+
+@pytest.mark.anyio
+async def test_generate_document_tool_spec_for_insurance_capability() -> None:
+    result = await generate_document_tool_spec("insurance")
+
+    assert result["name"] == "read_insurance_policy"
+    assert "coverage_summary" in result["returns"]
+    assert "claim_requirements" in result["returns"]

--- a/tests/unit/test_prompt_router.py
+++ b/tests/unit/test_prompt_router.py
@@ -26,6 +26,13 @@ def test_route_prompt_detects_document_intent() -> None:
     assert route.tool_name == "resolve_document_processing_flow"
 
 
+def test_route_prompt_detects_insurance_intent() -> None:
+    route = route_prompt("Read this insurance policy and explain coverage")
+
+    assert route.category == "document"
+    assert route.tool_name == "resolve_document_processing_flow"
+
+
 def test_route_prompt_rejects_blank_prompt() -> None:
     with pytest.raises(ToolError, match="message must not be empty"):
         route_prompt("   ")
@@ -71,6 +78,26 @@ async def test_execute_prompt_tool_accepts_frontend_message(monkeypatch: pytest.
     assert response.response == "document result"
     assert "resolve_document_processing_flow" in captured_prompts[0]
     assert "generic_structured_extraction" in captured_prompts[0]
+
+
+@pytest.mark.anyio
+async def test_execute_prompt_tool_routes_insurance_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_prompts: list[str] = []
+
+    async def fake_chat_with_ollama(prompt: str) -> str:
+        captured_prompts.append(prompt)
+        return "insurance result"
+
+    monkeypatch.setattr("services.prompt_router.chat_with_ollama", fake_chat_with_ollama)
+
+    response = await execute_prompt_tool(
+        PromptExecutionRequest(message="Read this insurance policy for claim requirements")
+    )
+
+    assert response.response == "insurance result"
+    assert "resolve_document_processing_flow" in captured_prompts[0]
+    assert "insurance_policy_reading" in captured_prompts[0]
+    assert "insurance policy" in captured_prompts[0]
 
 
 def test_get_prompt_route_endpoint_is_removed() -> None:


### PR DESCRIPTION
### Motivation

- Add support for insurance document workflows so the platform can read and summarize insurance policies, map scenarios to coverage/exclusions, and extract claim submission requirements.

### Description

- Introduce three new insurance skills as markdown guidance: `insurance-policy-reading`, `coverage-exclusions-analysis`, and `claims-requirements-extraction` under `skills/`.
- Register the new skills and an `insurance-document-reader-agent` in the document-processing blueprint by updating `DOCUMENT_BLUEPRINT` in `src/domain/blueprints.py` and expose them via `list_document_blueprint`/`list_platform_blueprints` tooling.
- Extend document tooling in `src/tools/backend.py` to: add checklist items for `insurance policy` in `generate_document_skill_set_tool`, insert an insurance-aware step and include `insurance-document-reader-agent` in `generate_document_agent_plan_tool`, and add an `insurance` capability in `generate_document_tool_spec_tool` (tool name `read_insurance_policy` with structured returns for `coverage_summary`, `exclusions`, and `claim_requirements`).
- Route insurance-related prompts by expanding document intent tokens in `src/services/prompt_router.py` to include `insurance`, `policy`, `coverage`, and `claim`, and return the `insurance_policy_reading` flow in `resolve_document_processing_flow_tool` when detected.
- Add documentation updates in `README.md` and `docs/mcp-skills-agents-tools.md` describing the insurance agent and skills.
- Add unit tests covering blueprint exposure, insurance routing, skill-set generation, agent plan inclusion, and `insurance` tool spec in `tests/unit/` and update prompt-router tests to assert insurance routing.
- Follow-up: recommend adding integration tests with representative insurance PDF fixtures and a production review of privacy/legal disclaimers before enabling on sensitive data.

### Testing

- Ran static compilation with `python -m compileall src tests`, which completed successfully.
- Ran the test suite with `pytest -q`, all tests passed (35 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06caef3e748328bbfec84b237a76f2)