### PR TITLE
feat: add CV reader agent and CV-related skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ pytest -q
 Coverage includes:
 - intent routing for Java/Spring, Node/Express/TypeScript, and Python/FastAPI;
 - insurance document-reading flow routing and agent/skill exposure;
+- CV/resume reading flow routing and agent/skill exposure;
 - invalid stack intent handling;
 - blueprint list contains expected generation skills.
 
@@ -89,6 +90,17 @@ Document-processing blueprints include an `insurance-document-reader-agent` for 
 - `claims-requirements-extraction`
 
 The insurance agent summarizes policy facts, coverage, exclusions, deadlines, and claim obligations from supplied document text, while flagging missing pages, ambiguous clauses, and items needing licensed or legal review.
+
+
+## CV/resume document-reading agent
+
+Document-processing blueprints include a `cv-reader-agent` for reading CVs, resumes, academic CVs, and candidate profiles. CV prompts such as “read this CV,” “summarize this resume,” or “extract candidate skills” route to the `cv_reading` flow and use these skills:
+
+- `cv-reading`
+- `candidate-profile-extraction`
+- `experience-skills-normalization`
+
+The CV reader agent extracts evidence-backed candidate facts, timelines, education, certifications, projects, skills, and review warnings from supplied document text while protecting PII and avoiding unsupported hiring decisions.
 
 ## Rotative logs for MCP tools
 

--- a/docs/mcp-skills-agents-tools.md
+++ b/docs/mcp-skills-agents-tools.md
@@ -153,3 +153,35 @@ Insurance policy requests are handled as document-processing workflows with a de
 - “Read this insurance policy and summarize coverage” -> `insurance_policy_reading`.
 - “Is water damage excluded in this policy?” -> `insurance_policy_reading` with `coverage-exclusions-analysis`.
 - “What documents do I need for this claim?” -> `insurance_policy_reading` with `claims-requirements-extraction`.
+
+
+## 7) CV/resume document-reading extension
+
+CV and resume requests are handled as document-processing workflows with a dedicated **cv-reader-agent**.
+
+### CV/resume skills
+
+1. **cv-reading**
+   - Reads CVs, resumes, academic CVs, candidate profiles, portfolios, and role-specific application documents.
+   - Produces evidence-backed candidate summaries, extracted facts, strengths, missing-information notes, and review warnings.
+
+2. **candidate-profile-extraction**
+   - Extracts identity, contact channels, work history, education, certifications, projects, publications, languages, links, and skills.
+   - Preserves field-level confidence, source references, and explicit “not found” markers for missing fields.
+
+3. **experience-skills-normalization**
+   - Normalizes chronology, durations, overlaps, gaps, technologies, domain keywords, and skills matrices.
+   - Links skills to supporting roles, projects, certifications, or education instead of inferring unsupported competencies.
+
+### CV/resume agent
+
+**cv-reader-agent**
+- Input: extracted CV/resume text, target role context, user question, optional language/region/compliance constraints.
+- Output: candidate profile, experience timeline, skills matrix, education/certification summary, confidence warnings, chronology issues, and human-review prompts.
+- Uses: `cv-reading`, `candidate-profile-extraction`, `experience-skills-normalization`, `document-validation`, and `pii-redaction`.
+
+### Routing examples
+
+- “Read this CV and summarize the candidate” -> `cv_reading`.
+- “Extract skills from this resume” -> `cv_reading` with `experience-skills-normalization`.
+- “Create a structured candidate profile from this curriculum vitae” -> `cv_reading` with `candidate-profile-extraction`.

--- a/skills/README.md
+++ b/skills/README.md
@@ -17,6 +17,9 @@ It also contains reusable document-processing skills:
 - `insurance-policy-reading`
 - `coverage-exclusions-analysis`
 - `claims-requirements-extraction`
+- `cv-reading`
+- `candidate-profile-extraction`
+- `experience-skills-normalization`
 - `document-processing-observability`
 
 ## Intent routing examples
@@ -32,3 +35,12 @@ Insurance-related prompts such as “read this insurance policy,” “summarize
 - `insurance-policy-reading` for policy declarations, endorsements, limits, deductibles, exclusions, and renewal/cancellation terms.
 - `coverage-exclusions-analysis` for mapping user scenarios to coverage grants, limits, exclusions, exceptions, and ambiguous clauses.
 - `claims-requirements-extraction` for notice duties, proof-of-loss requirements, evidence checklists, deadlines, and escalation paths.
+
+
+## CV and resume reading
+
+CV/resume prompts such as “read this CV,” “summarize this resume,” or “extract candidate skills” should route to the document-processing blueprint and use the `cv-reader-agent` with these skills:
+
+- `cv-reading` for evidence-backed summaries of candidate profile facts, work history, education, certifications, projects, languages, and warnings.
+- `candidate-profile-extraction` for converting CV/resume text into structured candidate fields with confidence and source references.
+- `experience-skills-normalization` for normalizing chronology, role durations, gaps, overlapping dates, technologies, and evidence-backed skills matrices.

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -38,3 +38,12 @@ Insurance document requests should use the `insurance-document-reader-agent` alo
 - `claims-requirements-extraction` when the user asks what is needed to submit or prepare a claim.
 
 These skills are document-reading support only. They should avoid legal or licensed-insurance advice and should flag ambiguous or missing policy text for human review.
+
+
+CV and resume requests should use the `cv-reader-agent` alongside:
+
+- `cv-reading` when the user asks to read, summarize, or extract facts from a CV/resume.
+- `candidate-profile-extraction` when the user needs structured candidate data for review or downstream systems.
+- `experience-skills-normalization` when the user needs normalized timelines, skills matrices, gap detection, or role/project evidence.
+
+These skills are document-reading support only. They should protect candidate PII, avoid protected-attribute inference, and avoid making hiring decisions without a separate compliant review process.

--- a/skills/candidate-profile-extraction.md
+++ b/skills/candidate-profile-extraction.md
@@ -1,0 +1,26 @@
+# candidate-profile-extraction
+
+## Purpose
+Provide guidance for the **candidate-profile-extraction** capability that converts CV/resume text into a structured, reviewable candidate profile.
+
+## Inputs
+- CV/resume source (path/URI or extracted text)
+- Optional target role profile, seniority expectations, and required schema
+- Processing context such as language, region, and privacy constraints
+
+## Outputs
+- Structured candidate profile with identity, contact, work history, education, certifications, projects, skills, languages, and links
+- Field-level confidence, source references, and “not found” markers for absent fields
+- Review notes for ambiguous titles, unknown employers, incomplete dates, and possible OCR/layout issues
+
+## Workflow
+1. Validate that the input is readable CV/resume content and identify its language and layout.
+2. Extract sections in order: header/contact, summary, experience, education, certifications, projects, skills, languages, publications, awards, and links.
+3. Normalize names of employers, schools, certifications, technologies, locations, and date formats without changing meaning.
+4. Attach source evidence and confidence to each extracted field.
+5. Return a deterministic structured profile plus human-readable review notes.
+
+## Operational guidance
+- Keep extraction evidence-backed and avoid adding facts from outside sources.
+- Redact or suppress unnecessary sensitive personal data when the downstream task does not require it.
+- Represent missing values explicitly rather than omitting required schema keys.

--- a/skills/cv-reading.md
+++ b/skills/cv-reading.md
@@ -1,0 +1,29 @@
+# cv-reading
+
+## Purpose
+Guide the **cv-reading** capability for CVs, resumes, candidate profiles, academic CVs, portfolios, and role-specific application documents.
+
+## Inputs
+- Document source (path/URI or extracted text)
+- Target role or evaluation context when available
+- Optional language, region, seniority level, and compliance constraints
+
+## Outputs
+- Concise candidate summary grounded only in the supplied CV content
+- Structured candidate facts: name, contact channels, location, target role, work history, education, certifications, projects, publications, languages, and links
+- Experience timeline with employers, titles, date ranges, duration estimates, responsibilities, achievements, and evidence snippets when available
+- Skills matrix grouped by technical skills, domain expertise, leadership, tools, and languages, with role/project evidence and confidence notes
+- Warnings for missing chronology, unexplained gaps, stale contact details, contradictory dates, unsupported skill claims, and low-confidence OCR spans
+
+## Workflow
+1. Classify the document as a CV, resume, academic CV, or candidate profile before extraction.
+2. Extract identity and contact fields, but avoid echoing unnecessary sensitive details in summaries.
+3. Build a chronological experience timeline and normalize date ranges, ongoing roles, overlaps, and gaps.
+4. Map skills to supporting evidence from roles, projects, education, or certifications instead of inferring unsupported capabilities.
+5. Summarize strengths, role fit signals, missing information, and human-review questions without making hiring decisions.
+
+## Operational guidance
+- Treat CV content as personal data; minimize PII in logs and outputs.
+- Do not infer protected attributes or make discriminatory recommendations.
+- Prefer “not found in provided CV” over guessing when fields are missing.
+- Preserve field-level confidence and source references when extraction tooling provides them.

--- a/skills/experience-skills-normalization.md
+++ b/skills/experience-skills-normalization.md
@@ -1,0 +1,25 @@
+# experience-skills-normalization
+
+## Purpose
+Guide the **experience-skills-normalization** capability for turning free-form CV experience and skill sections into a consistent timeline and skills matrix.
+
+## Inputs
+- Extracted CV sections or full CV text
+- Optional target role taxonomy, technology taxonomy, seniority rubric, and date normalization rules
+
+## Outputs
+- Normalized experience timeline with date ranges, durations, overlaps, gaps, titles, organizations, and evidence-backed achievements
+- Skills matrix grouped by category with proficiency evidence, recency signals, and role/project references
+- Warnings for ambiguous dates, unsupported skill claims, inflated keyword lists, duplicate roles, and chronology conflicts
+
+## Workflow
+1. Parse all date expressions, including month/year ranges, years-only ranges, “present,” and academic periods.
+2. Sort roles chronologically and compute approximate durations while preserving uncertainty.
+3. Link technologies and skills to the roles, projects, or certifications where they appear.
+4. Detect chronology gaps, overlapping positions, repeated employers, and inconsistent titles.
+5. Produce normalized values suitable for search, matching, summaries, and reviewer handoff.
+
+## Operational guidance
+- Never convert uncertainty into false precision; mark approximate dates clearly.
+- Do not score candidate suitability unless a separate, compliant evaluation rubric is supplied.
+- Avoid deriving protected or sensitive attributes from names, dates, locations, or institutions.

--- a/src/domain/blueprints.py
+++ b/src/domain/blueprints.py
@@ -95,6 +95,9 @@ DOCUMENT_BLUEPRINT: dict[str, list[str]] = {
         "insurance-policy-reading",
         "coverage-exclusions-analysis",
         "claims-requirements-extraction",
+        "cv-reading",
+        "candidate-profile-extraction",
+        "experience-skills-normalization",
         "document-processing-observability",
     ],
     "agents": [
@@ -102,6 +105,7 @@ DOCUMENT_BLUEPRINT: dict[str, list[str]] = {
         "document-extraction-agent",
         "document-validation-agent",
         "insurance-document-reader-agent",
+        "cv-reader-agent",
         "document-review-agent",
     ],
     "tools": [

--- a/src/server.py
+++ b/src/server.py
@@ -20,7 +20,11 @@ from tools.backend import (
     resolve_backend_skill_tool,
     resolve_document_processing_flow_tool,
 )
-from tools.document import build_document_prompt, extract_pdf_text, truncate_document_text
+from tools.document import (
+    build_document_prompt,
+    extract_pdf_text,
+    truncate_document_text,
+)
 
 mcp = FastMCP(name=SERVICE_NAME, mask_error_details=True)
 logger = get_logger()
@@ -32,7 +36,9 @@ async def send_prompt(prompt: str) -> str:
     return await chat_with_ollama(prompt)
 
 
-@mcp.tool(description="Extract text from a PDF file and answer a question using local Ollama.")
+@mcp.tool(
+    description="Extract text from a PDF file and answer a question using local Ollama."
+)
 async def process_pdf(file_path: str, question: str, max_chars: int = 30000) -> str:
     logger.info("Tool process_pdf called for file_path=%s", file_path)
     document_text = extract_pdf_text(file_path)
@@ -41,7 +47,9 @@ async def process_pdf(file_path: str, question: str, max_chars: int = 30000) -> 
     return await chat_with_ollama(prompt)
 
 
-@mcp.tool(description="Check Ollama reachability and verify the configured model exists.")
+@mcp.tool(
+    description="Check Ollama reachability and verify the configured model exists."
+)
 async def health_check() -> dict[str, Any]:
     logger.info("Tool health_check called")
     return await ollama_health()
@@ -55,22 +63,28 @@ async def list_backend_blueprints() -> dict[str, Any]:
 
 @mcp.tool(description="Generate a prioritized skill set for a backend stack.")
 async def generate_skill_set(stack: str, project_type: str = "api") -> dict[str, Any]:
-    logger.info("Tool generate_skill_set called for stack=%s project_type=%s", stack, project_type)
+    logger.info(
+        "Tool generate_skill_set called for stack=%s project_type=%s",
+        stack,
+        project_type,
+    )
     return generate_skill_set_tool(stack, project_type)
 
 
 @mcp.tool(description="Generate an agent execution plan for a backend feature.")
-async def generate_agent_plan(stack: str, feature_summary: str, constraints: str = "") -> dict[str, Any]:
+async def generate_agent_plan(
+    stack: str, feature_summary: str, constraints: str = ""
+) -> dict[str, Any]:
     logger.info("Tool generate_agent_plan called for stack=%s", stack)
     return generate_agent_plan_tool(stack, feature_summary, constraints)
 
 
-@mcp.tool(description="Resolve a user request to a recommended backend generation skill.")
+@mcp.tool(
+    description="Resolve a user request to a recommended backend generation skill."
+)
 async def resolve_backend_skill(user_request: str) -> dict[str, str]:
     logger.info("Tool resolve_backend_skill called")
     return resolve_backend_skill_tool(user_request)
-
-
 
 
 @mcp.tool(description="List all platform blueprints (backend + document processing).")
@@ -86,14 +100,24 @@ async def list_document_blueprint() -> dict[str, Any]:
 
 
 @mcp.tool(description="Generate a prioritized document-processing skill set.")
-async def generate_document_skill_set(document_type: str, compliance_mode: str = "standard") -> dict[str, Any]:
-    logger.info("Tool generate_document_skill_set called for document_type=%s compliance_mode=%s", document_type, compliance_mode)
+async def generate_document_skill_set(
+    document_type: str, compliance_mode: str = "standard"
+) -> dict[str, Any]:
+    logger.info(
+        "Tool generate_document_skill_set called for document_type=%s compliance_mode=%s",
+        document_type,
+        compliance_mode,
+    )
     return generate_document_skill_set_tool(document_type, compliance_mode)
 
 
 @mcp.tool(description="Generate an agent execution plan for document processing.")
-async def generate_document_agent_plan(document_type: str, objective: str, constraints: str = "") -> dict[str, Any]:
-    logger.info("Tool generate_document_agent_plan called for document_type=%s", document_type)
+async def generate_document_agent_plan(
+    document_type: str, objective: str, constraints: str = ""
+) -> dict[str, Any]:
+    logger.info(
+        "Tool generate_document_agent_plan called for document_type=%s", document_type
+    )
     return generate_document_agent_plan_tool(document_type, objective, constraints)
 
 
@@ -104,7 +128,7 @@ async def generate_document_tool_spec(capability: str) -> dict[str, Any]:
 
 
 @mcp.tool(description="Resolve a request to a recommended document-processing flow.")
-async def resolve_document_processing_flow(user_request: str) -> dict[str, str]:
+async def resolve_document_processing_flow(user_request: str) -> dict[str, Any]:
     logger.info("Tool resolve_document_processing_flow called")
     return resolve_document_processing_flow_tool(user_request)
 

--- a/src/tools/backend.py
+++ b/src/tools/backend.py
@@ -40,9 +40,21 @@ def generate_agent_plan_tool(
         "feature_summary": feature_summary,
         "constraints": constraints,
         "plan": [
-            {"step": 1, "agent": agents[0], "task": "Design architecture and contracts"},
-            {"step": 2, "agent": agents[1], "task": "Implement feature modules and tests"},
-            {"step": 3, "agent": agents[2], "task": "Run review checklist and release readiness"},
+            {
+                "step": 1,
+                "agent": agents[0],
+                "task": "Design architecture and contracts",
+            },
+            {
+                "step": 2,
+                "agent": agents[1],
+                "task": "Implement feature modules and tests",
+            },
+            {
+                "step": 3,
+                "agent": agents[2],
+                "task": "Run review checklist and release readiness",
+            },
         ],
     }
 
@@ -71,14 +83,18 @@ def resolve_backend_skill_tool(user_request: str) -> dict[str, str]:
             "reason": "Detected Python/FastAPI intent.",
         }
 
-    raise ToolError("Could not infer stack. Mention Java, Node/Express/TypeScript, or Python/FastAPI.")
+    raise ToolError(
+        "Could not infer stack. Mention Java, Node/Express/TypeScript, or Python/FastAPI."
+    )
 
 
 def list_document_blueprint_tool() -> dict[str, Any]:
     return {"document_processing": DOCUMENT_BLUEPRINT}
 
 
-def generate_document_skill_set_tool(document_type: str, compliance_mode: str = "standard") -> dict[str, Any]:
+def generate_document_skill_set_tool(
+    document_type: str, compliance_mode: str = "standard"
+) -> dict[str, Any]:
     doc_type = document_type.strip().lower()
     if not doc_type:
         raise ToolError("document_type must not be empty.")
@@ -90,9 +106,10 @@ def generate_document_skill_set_tool(document_type: str, compliance_mode: str = 
             "Flag duplicate invoice number risk",
         ],
         "curriculum vitae": [
-            "Extract identity, roles, education, skills",
-            "Normalize date ranges and durations",
-            "Flag missing chronology and overlapping periods",
+            "Extract candidate identity, contact channels, role targets, work history, education, certifications, projects, languages, and skills",
+            "Normalize date ranges, durations, seniority signals, technologies, and domain keywords",
+            "Map evidence-backed skills to roles or projects instead of inferring unsupported competencies",
+            "Flag missing chronology, unexplained gaps, overlapping periods, stale contact details, and low-confidence OCR spans",
         ],
         "insurance policy": [
             "Identify policyholder, insurer, policy number, effective dates, and renewal terms",
@@ -101,11 +118,14 @@ def generate_document_skill_set_tool(document_type: str, compliance_mode: str = 
             "Flag ambiguous clauses, missing schedules, and conflicts between declarations and endorsements",
         ],
     }
-    checklist = checklists.get(doc_type, [
-        "Classify document layout and language",
-        "Extract key fields with confidence scores",
-        "Validate required fields for downstream workflow",
-    ])
+    checklist = checklists.get(
+        doc_type,
+        [
+            "Classify document layout and language",
+            "Extract key fields with confidence scores",
+            "Validate required fields for downstream workflow",
+        ],
+    )
 
     return {
         "document_type": doc_type,
@@ -115,7 +135,9 @@ def generate_document_skill_set_tool(document_type: str, compliance_mode: str = 
     }
 
 
-def generate_document_agent_plan_tool(document_type: str, objective: str, constraints: str = "") -> dict[str, Any]:
+def generate_document_agent_plan_tool(
+    document_type: str, objective: str, constraints: str = ""
+) -> dict[str, Any]:
     if not objective.strip():
         raise ToolError("objective must not be empty.")
     doc_type = document_type.strip().lower()
@@ -124,21 +146,45 @@ def generate_document_agent_plan_tool(document_type: str, objective: str, constr
 
     agents = DOCUMENT_BLUEPRINT["agents"]
     plan = [
-        {"step": 1, "agent": agents[0], "task": "Classify document and choose extraction pipeline"},
-        {"step": 2, "agent": agents[1], "task": "Run OCR + structured field extraction with confidence scores"},
-        {"step": 3, "agent": agents[2], "task": "Validate business rules, required fields, and anomaly checks"},
+        {
+            "step": 1,
+            "agent": agents[0],
+            "task": "Classify document and choose extraction pipeline",
+        },
+        {
+            "step": 2,
+            "agent": agents[1],
+            "task": "Run OCR + structured field extraction with confidence scores",
+        },
+        {
+            "step": 3,
+            "agent": agents[2],
+            "task": "Validate business rules, required fields, and anomaly checks",
+        },
     ]
     if doc_type in {"insurance", "insurance policy", "policy"}:
-        plan.append({
-            "step": 4,
-            "agent": "insurance-document-reader-agent",
-            "task": "Read policy language, summarize coverage, exclusions, limits, deductibles, and claim obligations",
-        })
-    plan.append({
-        "step": len(plan) + 1,
-        "agent": "document-review-agent",
-        "task": "Generate review summary and remediation recommendations",
-    })
+        plan.append(
+            {
+                "step": 4,
+                "agent": "insurance-document-reader-agent",
+                "task": "Read policy language, summarize coverage, exclusions, limits, deductibles, and claim obligations",
+            }
+        )
+    if doc_type in {"cv", "resume", "curriculum vitae"}:
+        plan.append(
+            {
+                "step": 4,
+                "agent": "cv-reader-agent",
+                "task": "Read the CV, extract an evidence-backed candidate profile, normalize experience, and flag gaps or ambiguities",
+            }
+        )
+    plan.append(
+        {
+            "step": len(plan) + 1,
+            "agent": "document-review-agent",
+            "task": "Generate review summary and remediation recommendations",
+        }
+    )
     return {
         "document_type": doc_type,
         "objective": objective,
@@ -156,7 +202,34 @@ def generate_document_tool_spec_tool(capability: str) -> dict[str, Any]:
         "insurance": {
             "name": "read_insurance_policy",
             "args": ["document_uri", "policy_profile", "jurisdiction"],
-            "returns": ["coverage_summary", "exclusions", "claim_requirements", "warnings"],
+            "returns": [
+                "coverage_summary",
+                "exclusions",
+                "claim_requirements",
+                "warnings",
+            ],
+        },
+        "cv": {
+            "name": "read_cv",
+            "args": ["document_uri", "role_profile", "language"],
+            "returns": [
+                "candidate_profile",
+                "experience_timeline",
+                "skills_matrix",
+                "education",
+                "warnings",
+            ],
+        },
+        "resume": {
+            "name": "read_cv",
+            "args": ["document_uri", "role_profile", "language"],
+            "returns": [
+                "candidate_profile",
+                "experience_timeline",
+                "skills_matrix",
+                "education",
+                "warnings",
+            ],
         },
         "extract": {
             "name": "extract_document_fields",
@@ -174,11 +247,14 @@ def generate_document_tool_spec_tool(capability: str) -> dict[str, Any]:
             "returns": ["redacted_document_uri", "redaction_map"],
         },
     }
-    resolved = specs.get(cap, {
-        "name": f"document_{cap}_tool",
-        "args": ["payload"],
-        "returns": ["result"],
-    })
+    resolved = specs.get(
+        cap,
+        {
+            "name": f"document_{cap}_tool",
+            "args": ["payload"],
+            "returns": ["result"],
+        },
+    )
     resolved["error_guidance"] = [
         "Return explicit field-level errors for extraction failures",
         "Include remediation hints when confidence is below threshold",
@@ -186,7 +262,7 @@ def generate_document_tool_spec_tool(capability: str) -> dict[str, Any]:
     return resolved
 
 
-def resolve_document_processing_flow_tool(user_request: str) -> dict[str, str]:
+def resolve_document_processing_flow_tool(user_request: str) -> dict[str, Any]:
     text = user_request.strip().lower()
     if not text:
         raise ToolError("user_request must not be empty.")
@@ -206,8 +282,16 @@ def resolve_document_processing_flow_tool(user_request: str) -> dict[str, str]:
     if "cv" in text or "resume" in text or "curriculum vitae" in text:
         return {
             "document_type": "curriculum vitae",
-            "flow": "candidate_profile_extraction",
-            "reason": "Detected CV/resume processing intent.",
+            "flow": "cv_reading",
+            "agent": "cv-reader-agent",
+            "skills": [
+                "cv-reading",
+                "candidate-profile-extraction",
+                "experience-skills-normalization",
+                "document-validation",
+                "pii-redaction",
+            ],
+            "reason": "Detected CV/resume reading intent.",
         }
 
     return {

--- a/tests/unit/test_backend_skills.py
+++ b/tests/unit/test_backend_skills.py
@@ -50,7 +50,10 @@ async def test_list_backend_blueprints_contains_skills() -> None:
     data = await list_backend_blueprints()
     assert "stacks" in data
     assert "java_spring_boot" in data["stacks"]
-    assert "generate-spring-boot-java-backend" in data["stacks"]["java_spring_boot"]["skills"]
+    assert (
+        "generate-spring-boot-java-backend"
+        in data["stacks"]["java_spring_boot"]["skills"]
+    )
 
 
 @pytest.mark.anyio
@@ -72,6 +75,61 @@ async def test_list_platform_blueprints_contains_insurance_agent_and_skills() ->
     assert "insurance-policy-reading" in document_processing["skills"]
     assert "coverage-exclusions-analysis" in document_processing["skills"]
     assert "claims-requirements-extraction" in document_processing["skills"]
+
+
+@pytest.mark.anyio
+async def test_list_platform_blueprints_contains_cv_agent_and_skills() -> None:
+    data = await list_platform_blueprints()
+
+    document_processing = data["document_processing"]
+
+    assert "cv-reader-agent" in document_processing["agents"]
+    assert "cv-reading" in document_processing["skills"]
+    assert "candidate-profile-extraction" in document_processing["skills"]
+    assert "experience-skills-normalization" in document_processing["skills"]
+
+
+@pytest.mark.anyio
+async def test_resolve_document_processing_flow_detects_cv_reading() -> None:
+    result = await resolve_document_processing_flow(
+        "Read this CV and summarize candidate skills"
+    )
+
+    assert result["document_type"] == "curriculum vitae"
+    assert result["flow"] == "cv_reading"
+    assert result["agent"] == "cv-reader-agent"
+    assert "cv-reading" in result["skills"]
+
+
+@pytest.mark.anyio
+async def test_generate_document_skill_set_for_curriculum_vitae() -> None:
+    result = await generate_document_skill_set("curriculum vitae")
+
+    assert result["document_type"] == "curriculum vitae"
+    assert "cv-reading" in result["priority_skills"]
+    assert any("candidate identity" in item for item in result["checklist"])
+
+
+@pytest.mark.anyio
+async def test_generate_document_agent_plan_uses_cv_reader_agent() -> None:
+    result = await generate_document_agent_plan(
+        "curriculum vitae",
+        "Extract a candidate profile and normalize skills",
+    )
+
+    agents = [step["agent"] for step in result["plan"]]
+
+    assert "cv-reader-agent" in agents
+    assert agents[-1] == "document-review-agent"
+
+
+@pytest.mark.anyio
+async def test_generate_document_tool_spec_for_cv_capability() -> None:
+    result = await generate_document_tool_spec("cv")
+
+    assert result["name"] == "read_cv"
+    assert "candidate_profile" in result["returns"]
+    assert "skills_matrix" in result["returns"]
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_prompt_router.py
+++ b/tests/unit/test_prompt_router.py
@@ -9,7 +9,11 @@ from starlette.testclient import TestClient
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
 from http_api import create_app
-from services.prompt_router import PromptExecutionRequest, execute_prompt_tool, route_prompt
+from services.prompt_router import (
+    PromptExecutionRequest,
+    execute_prompt_tool,
+    route_prompt,
+)
 
 
 def test_route_prompt_detects_backend_intent() -> None:
@@ -33,20 +37,31 @@ def test_route_prompt_detects_insurance_intent() -> None:
     assert route.tool_name == "resolve_document_processing_flow"
 
 
+def test_route_prompt_detects_cv_reading_intent() -> None:
+    route = route_prompt("Read this CV and summarize the candidate profile")
+
+    assert route.category == "document"
+    assert route.tool_name == "resolve_document_processing_flow"
+
+
 def test_route_prompt_rejects_blank_prompt() -> None:
     with pytest.raises(ToolError, match="message must not be empty"):
         route_prompt("   ")
 
 
 @pytest.mark.anyio
-async def test_execute_prompt_tool_calls_inferred_backend_tool(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_execute_prompt_tool_calls_inferred_backend_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     captured_prompts: list[str] = []
 
     async def fake_chat_with_ollama(prompt: str) -> str:
         captured_prompts.append(prompt)
         return "generated backend result"
 
-    monkeypatch.setattr("services.prompt_router.chat_with_ollama", fake_chat_with_ollama)
+    monkeypatch.setattr(
+        "services.prompt_router.chat_with_ollama", fake_chat_with_ollama
+    )
 
     response = await execute_prompt_tool(
         PromptExecutionRequest(message="Build Node API with Express and TypeScript")
@@ -60,14 +75,18 @@ async def test_execute_prompt_tool_calls_inferred_backend_tool(monkeypatch: pyte
 
 
 @pytest.mark.anyio
-async def test_execute_prompt_tool_accepts_frontend_message(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_execute_prompt_tool_accepts_frontend_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     captured_prompts: list[str] = []
 
     async def fake_chat_with_ollama(prompt: str) -> str:
         captured_prompts.append(prompt)
         return "document result"
 
-    monkeypatch.setattr("services.prompt_router.chat_with_ollama", fake_chat_with_ollama)
+    monkeypatch.setattr(
+        "services.prompt_router.chat_with_ollama", fake_chat_with_ollama
+    )
 
     response = await execute_prompt_tool(
         PromptExecutionRequest.model_validate(
@@ -81,17 +100,48 @@ async def test_execute_prompt_tool_accepts_frontend_message(monkeypatch: pytest.
 
 
 @pytest.mark.anyio
-async def test_execute_prompt_tool_routes_insurance_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_execute_prompt_tool_routes_cv_reading(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_prompts: list[str] = []
+
+    async def fake_chat_with_ollama(prompt: str) -> str:
+        captured_prompts.append(prompt)
+        return "cv result"
+
+    monkeypatch.setattr(
+        "services.prompt_router.chat_with_ollama", fake_chat_with_ollama
+    )
+
+    response = await execute_prompt_tool(
+        PromptExecutionRequest(message="Read this CV and extract skills")
+    )
+
+    assert response.response == "cv result"
+    assert "resolve_document_processing_flow" in captured_prompts[0]
+    assert "cv_reading" in captured_prompts[0]
+    assert "cv-reader-agent" in captured_prompts[0]
+    assert "cv-reading" in captured_prompts[0]
+
+
+@pytest.mark.anyio
+async def test_execute_prompt_tool_routes_insurance_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     captured_prompts: list[str] = []
 
     async def fake_chat_with_ollama(prompt: str) -> str:
         captured_prompts.append(prompt)
         return "insurance result"
 
-    monkeypatch.setattr("services.prompt_router.chat_with_ollama", fake_chat_with_ollama)
+    monkeypatch.setattr(
+        "services.prompt_router.chat_with_ollama", fake_chat_with_ollama
+    )
 
     response = await execute_prompt_tool(
-        PromptExecutionRequest(message="Read this insurance policy for claim requirements")
+        PromptExecutionRequest(
+            message="Read this insurance policy for claim requirements"
+        )
     )
 
     assert response.response == "insurance result"
@@ -103,16 +153,22 @@ async def test_execute_prompt_tool_routes_insurance_policy(monkeypatch: pytest.M
 def test_get_prompt_route_endpoint_is_removed() -> None:
     client = TestClient(create_app())
 
-    response = client.get("/api/prompts/route", params={"prompt": "Need a Java backend"})
+    response = client.get(
+        "/api/prompts/route", params={"prompt": "Need a Java backend"}
+    )
 
     assert response.status_code == 404
 
 
-def test_post_prompt_execute_endpoint_returns_only_response(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_post_prompt_execute_endpoint_returns_only_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     async def fake_chat_with_ollama(_: str) -> str:
         return "Process the resume with structured extraction."
 
-    monkeypatch.setattr("services.prompt_router.chat_with_ollama", fake_chat_with_ollama)
+    monkeypatch.setattr(
+        "services.prompt_router.chat_with_ollama", fake_chat_with_ollama
+    )
     client = TestClient(create_app())
 
     response = client.post(
@@ -121,7 +177,9 @@ def test_post_prompt_execute_endpoint_returns_only_response(monkeypatch: pytest.
     )
 
     assert response.status_code == 200
-    assert response.json() == {"response": "Process the resume with structured extraction."}
+    assert response.json() == {
+        "response": "Process the resume with structured extraction."
+    }
 
 
 def test_post_prompt_execute_rejects_extra_fields() -> None:
@@ -156,7 +214,9 @@ def test_openapi_schema_documents_prompt_routes() -> None:
     assert "/api/prompts/route" not in schema["paths"]
     assert "/api/prompts/execute" in schema["paths"]
     assert "PromptExecutionRequest" in schema["components"]["schemas"]
-    assert schema["components"]["schemas"]["PromptExecutionRequest"]["properties"].keys() == {"message"}
+    assert schema["components"]["schemas"]["PromptExecutionRequest"][
+        "properties"
+    ].keys() == {"message"}
 
 
 def test_http_dependency_checker_reports_missing_modules() -> None:


### PR DESCRIPTION
### Motivation
- Add first-class support for CV/resume document workflows so the platform can extract evidence-backed candidate profiles, normalize experience and skills, and surface review guidance without mixing with insurance flows.
- Provide explicit skills, agent wiring, and tool specs to make CV handling discoverable and routable by the MCP prompt router and blueprints.

### Description
- Registered new document-processing skills and an agent by adding `cv-reading`, `candidate-profile-extraction`, `experience-skills-normalization`, and `cv-reader-agent` to `DOCUMENT_BLUEPRINT` in `src/domain/blueprints.py`.
- Extended document tooling in `src/tools/backend.py` to include a CV-specific checklist, append the `cv-reader-agent` to generated agent plans for CV/resume types, add `read_cv` (`read_cv`) tool specs for `cv` and `resume` capabilities, and route CV prompts via `resolve_document_processing_flow_tool` returning `cv_reading` with `agent` and `skills` metadata.
- Added human-readable skill guides under `skills/` (`cv-reading.md`, `candidate-profile-extraction.md`, `experience-skills-normalization.md`) and updated `skills/README.md`, `skills/SKILL.md`, `docs/mcp-skills-agents-tools.md`, and `README.md` to document the CV/resume agent and routing examples.
- Added unit tests to `tests/unit/test_backend_skills.py` and `tests/unit/test_prompt_router.py` to cover blueprint exposure, CV flow resolution, CV skill-set generation, CV agent planning, `read_cv` tool spec generation, and prompt-router execution context for CV prompts.

### Testing
- Ran formatting and checks with `python -m black --check src/server.py src/tools/backend.py tests/unit/test_backend_skills.py tests/unit/test_prompt_router.py`, formatted impacted files, and re-ran the check successfully.
- Compiled code with `python -m compileall src tests` which completed without errors.
- Executed unit tests with `pytest -q` and observed all tests passing (`42 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06d74790fc83289a49c1d28c5242dd)