### PR TITLE
feat: add docker-compose.yml for Qdrant service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  qdrant:
+    image: qdrant/qdrant
+    container_name: qdrant
+    ports:
+      - "6333:6333"
+      - "6334:6334"
+    volumes:
+      - ./qdrant_storage:/qdrant/storage


### PR DESCRIPTION
### Motivation
- Provide a simple, reproducible local setup for running Qdrant with Docker Compose to support vector DB development and testing.

### Description
- Add `docker-compose.yml` at the repository root defining a `qdrant` service using `qdrant/qdrant`, setting `container_name: qdrant`, exposing ports `6333` and `6334`, and mounting `./qdrant_storage:/qdrant/storage` for persistence.

### Testing
- Ran `python -m compileall src` and `pytest -q`, which both succeeded (`48 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c13a2adec8328b8002c6b9707e609)