### PR TITLE
Make Qdrant storage path configurable via env, add .env.example, update docs and .gitignore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+QDRANT_STORAGE_PATH=./qdrant_storage

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ __pycache__/
 # generated projects
 data/*
 !data/.gitkeep
+
+# local environment overrides
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,4 +6,4 @@ services:
       - "6333:6333"
       - "6334:6334"
     volumes:
-      - ./qdrant_storage:/qdrant/storage
+      - ${QDRANT_STORAGE_PATH:-./qdrant_storage}:/qdrant/storage

--- a/docs/runbooks/vector-database.md
+++ b/docs/runbooks/vector-database.md
@@ -31,6 +31,21 @@ ollama pull nomic-embed-text
 QDRANT_URL=http://127.0.0.1:6333 python src/server.py
 ```
 
+
+If you start Qdrant with `docker compose`, set `QDRANT_STORAGE_PATH` in a local `.env` file so data is stored on your machine:
+
+```env
+QDRANT_STORAGE_PATH=/absolute/path/on/your/machine
+```
+
+Then run:
+
+```bash
+docker compose up -d qdrant
+```
+
+You can copy from `.env.example` and update the path for your machine.
+
 Then call `initialize_vector_database` once. After that:
 
 - call `process_candidate_pdf` for CV/resume PDFs; it extracts structured candidate JSON, creates an embedding, and upserts into the `candidates` collection.


### PR DESCRIPTION
### Motivation
- Allow storing Qdrant data on the host by making the Compose volume path configurable via an environment variable.
- Provide a non-committed local environment override and avoid accidentally committing it by adding `.env.example` and ignoring `.env`.

### Description
- Add `.env.example` with `QDRANT_STORAGE_PATH=./qdrant_storage` as a template for local overrides.
- Change `docker-compose.yml` to mount the Qdrant storage using `${QDRANT_STORAGE_PATH:-./qdrant_storage}:/qdrant/storage` so a default is preserved when the env var is not set.
- Update `.gitignore` to ignore local `.env` files and adjust minor formatting.
- Update `docs/runbooks/vector-database.md` with instructions to set `QDRANT_STORAGE_PATH` in a local `.env` and to start Qdrant with `docker compose up -d qdrant`.

### Testing
- No automated tests were added or modified for this change.
- No automated test suite was run for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c17e8f2508328b0036c364432238f)