### PR TITLE
chore: remove qdrant storage fallback path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-QDRANT_STORAGE_PATH=./qdrant_storage
+QDRANT_STORAGE_PATH=/absolute/path/on/your/machine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,4 +6,4 @@ services:
       - "6333:6333"
       - "6334:6334"
     volumes:
-      - ${QDRANT_STORAGE_PATH:-./qdrant_storage}:/qdrant/storage
+      - ${QDRANT_STORAGE_PATH}:/qdrant/storage


### PR DESCRIPTION
### Motivation
- Make the Qdrant storage path explicit and require operators to set `QDRANT_STORAGE_PATH` in their local `.env` instead of falling back to a repository-local `./qdrant_storage` path.

### Description
- Updated `docker-compose.yml` to replace the fallback `${QDRANT_STORAGE_PATH:-./qdrant_storage}` with `${QDRANT_STORAGE_PATH}` and updated `.env.example` to `QDRANT_STORAGE_PATH=/absolute/path/on/your/machine` to document the required value.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c26f4072083289fda88ef91a4bef2)