### PR TITLE
feat: add structured logging across services with db focus

### DIFF
--- a/src/clients/ollama.py
+++ b/src/clients/ollama.py
@@ -11,9 +11,13 @@ from config import (
     OLLAMA_TIMEOUT_SECONDS,
     OLLAMA_URL,
 )
+from logging_config import get_logger
+
+logger = get_logger()
 
 
 async def chat_with_ollama(prompt: str) -> str:
+    logger.debug("Calling Ollama chat with prompt_length=%s", len(prompt))
     if not prompt.strip():
         raise ToolError("Prompt must not be empty.")
 
@@ -29,11 +33,13 @@ async def chat_with_ollama(prompt: str) -> str:
             response.raise_for_status()
             data = response.json()
     except httpx.ReadTimeout as exc:
+        logger.error("Ollama chat timed out.")
         raise ToolError(
             f"Ollama timed out after {OLLAMA_TIMEOUT_SECONDS:.0f}s. "
             "Try a smaller document, a faster model, or increase OLLAMA_TIMEOUT_SECONDS."
         ) from exc
     except httpx.HTTPError as exc:
+        logger.error("Ollama chat request failed at url=%s", OLLAMA_URL)
         raise ToolError(
             f"Failed to reach Ollama at {OLLAMA_URL}. Ensure 'ollama serve' is running."
         ) from exc
@@ -46,12 +52,14 @@ async def chat_with_ollama(prompt: str) -> str:
 
 
 async def ollama_health() -> dict[str, Any]:
+    logger.debug("Checking Ollama health at url=%s", OLLAMA_URL)
     try:
         async with httpx.AsyncClient(timeout=20.0) as client:
             tags_resp = await client.get(f"{OLLAMA_URL}/api/tags")
             tags_resp.raise_for_status()
             models = tags_resp.json().get("models", [])
     except httpx.HTTPError as exc:
+        logger.error("Ollama health check failed at url=%s", OLLAMA_URL)
         raise ToolError(
             f"Ollama is not reachable at {OLLAMA_URL}. Start it with: ollama serve"
         ) from exc
@@ -66,6 +74,7 @@ async def ollama_health() -> dict[str, Any]:
 
 
 async def embed_with_ollama(text: str) -> list[float]:
+    logger.debug("Calling Ollama embeddings with text_length=%s", len(text))
     if not text.strip():
         raise ToolError("Text to embed must not be empty.")
 
@@ -80,11 +89,13 @@ async def embed_with_ollama(text: str) -> list[float]:
             response.raise_for_status()
             data = response.json()
     except httpx.ReadTimeout as exc:
+        logger.error("Ollama embedding request timed out.")
         raise ToolError(
             f"Ollama embedding timed out after {OLLAMA_TIMEOUT_SECONDS:.0f}s. "
             "Try a smaller document or increase OLLAMA_TIMEOUT_SECONDS."
         ) from exc
     except httpx.HTTPError as exc:
+        logger.error("Ollama embedding request failed at url=%s", OLLAMA_URL)
         raise ToolError(
             f"Failed to reach Ollama embeddings at {OLLAMA_URL}. "
             "Ensure 'ollama serve' is running."

--- a/src/repositories/vector_database.py
+++ b/src/repositories/vector_database.py
@@ -8,10 +8,12 @@ from fastmcp.exceptions import ToolError
 
 from config import QDRANT_API_KEY, QDRANT_TIMEOUT_SECONDS, QDRANT_URL, VECTOR_SIZE
 from domain.vector_records import CandidateRecord, InsuranceRecord
+from logging_config import get_logger
 
 CANDIDATES_COLLECTION = "candidates"
 INSURANCES_COLLECTION = "insurances"
 VECTOR_DISTANCE = "Cosine"
+logger = get_logger()
 
 COLLECTION_SCHEMAS: dict[str, dict[str, Any]] = {
     CANDIDATES_COLLECTION: {
@@ -69,6 +71,7 @@ COLLECTION_SCHEMAS: dict[str, dict[str, Any]] = {
 
 
 def validate_embedding(embedding: Sequence[float]) -> list[float]:
+    logger.debug("Validating embedding vector with length=%s", len(embedding))
     if not embedding:
         raise ToolError("Embedding vector must not be empty.")
     if len(embedding) != VECTOR_SIZE:
@@ -80,6 +83,11 @@ def validate_embedding(embedding: Sequence[float]) -> list[float]:
 
 
 async def init_vector_database() -> None:
+    logger.info(
+        "Initializing vector database at url=%s for collections=%s",
+        QDRANT_URL,
+        ", ".join((CANDIDATES_COLLECTION, INSURANCES_COLLECTION)),
+    )
     client = _build_qdrant_client()
     try:
         await _ensure_collection(client, CANDIDATES_COLLECTION)
@@ -93,6 +101,7 @@ async def save_candidate_record(
     source_document_text: str,
     embedding: Sequence[float],
 ) -> str:
+    logger.info("Saving candidate record to collection=%s", CANDIDATES_COLLECTION)
     vector = validate_embedding(embedding)
     payload = _build_payload(candidate.model_dump(mode="json"), source_document_text)
     point_id = _candidate_point_id(candidate)
@@ -105,6 +114,7 @@ async def save_insurance_record(
     source_document_text: str,
     embedding: Sequence[float],
 ) -> str:
+    logger.info("Saving insurance record to collection=%s", INSURANCES_COLLECTION)
     vector = validate_embedding(embedding)
     payload = _build_payload(insurance.model_dump(mode="json"), source_document_text)
     point_id = _insurance_point_id(insurance)
@@ -116,8 +126,15 @@ async def _ensure_collection(client: Any, collection_name: str) -> None:
     qdrant_models = _load_qdrant_models()
     exists = await client.collection_exists(collection_name=collection_name)
     if exists:
+        logger.debug("Collection already exists: %s", collection_name)
         return
 
+    logger.info(
+        "Creating missing collection=%s with vector_size=%s distance=%s",
+        collection_name,
+        VECTOR_SIZE,
+        VECTOR_DISTANCE,
+    )
     await client.create_collection(
         collection_name=collection_name,
         vectors_config=qdrant_models.VectorParams(
@@ -133,6 +150,12 @@ async def _upsert_point(
     vector: list[float],
     payload: dict[str, Any],
 ) -> None:
+    logger.info(
+        "Upserting point id=%s into collection=%s payload_keys=%s",
+        point_id,
+        collection_name,
+        sorted(payload.keys()),
+    )
     client = _build_qdrant_client()
     qdrant_models = _load_qdrant_models()
     try:
@@ -173,6 +196,11 @@ def _insurance_point_id(insurance: InsuranceRecord) -> str:
 
 
 def _build_qdrant_client() -> Any:
+    logger.debug(
+        "Building Qdrant client for url=%s timeout=%ss",
+        QDRANT_URL,
+        QDRANT_TIMEOUT_SECONDS,
+    )
     qdrant_client_module = _load_qdrant_client_module()
     return qdrant_client_module.AsyncQdrantClient(
         url=QDRANT_URL,
@@ -185,6 +213,7 @@ def _load_qdrant_client_module() -> Any:
     from importlib.util import find_spec
 
     if find_spec("qdrant_client") is None:
+        logger.error("qdrant-client dependency is missing.")
         raise ToolError(
             "qdrant-client is required for vector database persistence. "
             "Install project dependencies with `python -m pip install -e .`."

--- a/src/services/document_upload.py
+++ b/src/services/document_upload.py
@@ -8,11 +8,13 @@ from pydantic import BaseModel, ConfigDict, Field
 from starlette.datastructures import UploadFile
 
 from clients.ollama import chat_with_ollama
+from logging_config import get_logger
 from tools.document import (
     build_document_prompt,
     extract_pdf_text,
     truncate_document_text,
 )
+logger = get_logger()
 
 
 class PdfUploadRequest(BaseModel):
@@ -43,6 +45,7 @@ async def process_pdf_upload(
     Ollama does not receive or parse the raw PDF binary. Image-only or scanned PDFs
     without an extractable text layer require OCR before this endpoint can answer.
     """
+    logger.info("Processing PDF upload filename=%s", upload.filename or "")
     _validate_pdf_upload(upload)
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_path = Path(temp_dir) / "upload.pdf"
@@ -61,6 +64,7 @@ def _validate_pdf_upload(upload: UploadFile) -> None:
     if not filename.lower().endswith(".pdf"):
         raise ToolError("Uploaded file must use a .pdf filename.")
     if content_type and content_type not in ("application/pdf", "application/x-pdf"):
+        logger.warning("Rejected upload with invalid content_type=%s", content_type)
         raise ToolError(
             f"Uploaded file must be a PDF, got content type: {content_type}"
         )
@@ -74,5 +78,6 @@ async def _write_upload_to_file(upload: UploadFile, destination: Path) -> None:
             file_obj.write(chunk)
 
     await upload.close()
+    logger.debug("Wrote upload to temp file bytes=%s", bytes_written)
     if bytes_written == 0:
         raise ToolError("Uploaded PDF is empty.")

--- a/src/services/prompt_router.py
+++ b/src/services/prompt_router.py
@@ -7,6 +7,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, ConfigDict, Field
 
 from clients.ollama import chat_with_ollama, ollama_health
+from logging_config import get_logger
 from tools.backend import (
     generate_agent_plan_tool,
     generate_document_agent_plan_tool,
@@ -21,6 +22,7 @@ from tools.backend import (
 )
 
 PromptCategory = Literal["backend", "document", "health", "chat"]
+logger = get_logger()
 
 
 class PromptRoute(BaseModel):
@@ -127,6 +129,7 @@ async def execute_prompt_tool(
     request: PromptExecutionRequest,
 ) -> PromptExecutionResponse:
     route = route_prompt(request.message)
+    logger.info("Prompt routed to tool=%s category=%s", route.tool_name, route.category)
 
     if route.tool_name == "send_prompt":
         model_prompt = request.message
@@ -153,6 +156,7 @@ def _build_model_prompt(prompt: str, route: PromptRoute, tool_result: Any) -> st
 
 
 async def _execute_tool(tool_name: str, prompt: str, arguments: dict[str, Any]) -> Any:
+    logger.debug("Executing routed tool=%s", tool_name)
     async_tools: dict[str, Callable[[], Any]] = {
         "send_prompt": lambda: chat_with_ollama(str(_argument(arguments, "prompt", prompt))),
         "health_check": ollama_health,

--- a/src/services/vector_document_ingestion.py
+++ b/src/services/vector_document_ingestion.py
@@ -8,16 +8,19 @@ from pydantic import ValidationError
 
 from clients.ollama import chat_with_ollama, embed_with_ollama
 from domain.vector_records import CandidateRecord, InsuranceRecord
+from logging_config import get_logger
 from repositories.vector_database import save_candidate_record, save_insurance_record
 from tools.document import extract_pdf_text, truncate_document_text
 
 DocumentAgent = Literal["cv-reader-agent", "insurance-document-reader-agent"]
+logger = get_logger()
 
 
 async def process_candidate_pdf_to_vector_db(
     file_path: str,
     max_chars: int = 30000,
 ) -> dict[str, Any]:
+    logger.info("Processing candidate PDF for vector DB file_path=%s", file_path)
     document_text = truncate_document_text(
         extract_pdf_text(file_path), max_chars=max_chars
     )
@@ -50,6 +53,7 @@ async def process_insurance_pdf_to_vector_db(
     file_path: str,
     max_chars: int = 30000,
 ) -> dict[str, Any]:
+    logger.info("Processing insurance PDF for vector DB file_path=%s", file_path)
     document_text = truncate_document_text(
         extract_pdf_text(file_path), max_chars=max_chars
     )
@@ -87,6 +91,7 @@ async def _extract_structured_json(
     schema_name: str,
     instructions: str,
 ) -> dict[str, Any]:
+    logger.debug("Extracting structured JSON with agent=%s schema=%s", agent, schema_name)
     prompt = (
         f"You are {agent}. Extract a {schema_name} from the PDF text.\n"
         f"{instructions}\n\n"
@@ -107,6 +112,7 @@ def _parse_json_object(raw_response: str) -> dict[str, Any]:
     try:
         value = json.loads(text)
     except json.JSONDecodeError as exc:
+        logger.error("Model response is not valid JSON for vector persistence.")
         raise ToolError(
             "Model did not return valid JSON for vector database persistence."
         ) from exc
@@ -121,6 +127,7 @@ def _validate_candidate(payload: dict[str, Any]) -> CandidateRecord:
     try:
         return CandidateRecord.model_validate(payload)
     except ValidationError as exc:
+        logger.error("Candidate payload validation failed.")
         raise ToolError(
             f"Candidate extraction did not match the candidates schema: {exc}"
         ) from exc
@@ -130,6 +137,7 @@ def _validate_insurance(payload: dict[str, Any]) -> InsuranceRecord:
     try:
         return InsuranceRecord.model_validate(payload)
     except ValidationError as exc:
+        logger.error("Insurance payload validation failed.")
         raise ToolError(
             f"Insurance extraction did not match the insurances schema: {exc}"
         ) from exc


### PR DESCRIPTION
### Motivation
- Improve operational observability for the project with a primary focus on the vector database ingestion and persistence path. 
- Surface actionable events and errors (client construction failures, embedding validation issues, model JSON parse/schema validation failures) to make local troubleshooting and diagnostics easier.

### Description
- Added structured logging (`get_logger()` + module-level `logger`) and debug/info/error statements across the vector DB repository (`src/repositories/vector_database.py`) covering `validate_embedding`, `init_vector_database`, collection checks/creation, `_upsert_point`, client construction, and missing dependency failures. 
- Instrumented the ingestion flow in `src/services/vector_document_ingestion.py` with logs for PDF processing, JSON extraction (`_extract_structured_json`), and schema validation failures for `CandidateRecord` and `InsuranceRecord`. 
- Added request/response and error logging to the Ollama client in `src/clients/ollama.py` for chat, embed, and health calls to help diagnose timeouts and connectivity issues. 
- Added lightweight observability to the PDF upload pipeline (`src/services/document_upload.py`) and prompt routing (`src/services/prompt_router.py`) to record upload metadata, rejected content types, bytes written, routing decisions, and executed tools.

### Testing
- Ran `python -m compileall src` and compilation completed successfully. 
- Ran unit tests with `pytest -q` and all tests passed (`48 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c2e14ad908328bc9c7e9b0889c795)