### PR TITLE
feat: include id in vector payload schemas for candidates and insurances

### DIFF
--- a/src/repositories/vector_database.py
+++ b/src/repositories/vector_database.py
@@ -19,6 +19,7 @@ COLLECTION_SCHEMAS: dict[str, dict[str, Any]] = {
     CANDIDATES_COLLECTION: {
         "description": "CV/resume extraction output written by cv-reader-agent.",
         "payload_fields": [
+            "id",
             "first_name",
             "last_name",
             "email",
@@ -41,6 +42,7 @@ COLLECTION_SCHEMAS: dict[str, dict[str, Any]] = {
     INSURANCES_COLLECTION: {
         "description": "Insurance extraction output written by insurance-document-reader-agent.",
         "payload_fields": [
+            "id",
             "insurance_number",
             "candidate_id",
             "insurance_type",
@@ -103,8 +105,8 @@ async def save_candidate_record(
 ) -> str:
     logger.info("Saving candidate record to collection=%s", CANDIDATES_COLLECTION)
     vector = validate_embedding(embedding)
-    payload = _build_payload(candidate.model_dump(mode="json"), source_document_text)
     point_id = _candidate_point_id(candidate)
+    payload = _build_payload(candidate.model_dump(mode="json"), source_document_text, point_id)
     await _upsert_point(CANDIDATES_COLLECTION, point_id, vector, payload)
     return point_id
 
@@ -116,8 +118,8 @@ async def save_insurance_record(
 ) -> str:
     logger.info("Saving insurance record to collection=%s", INSURANCES_COLLECTION)
     vector = validate_embedding(embedding)
-    payload = _build_payload(insurance.model_dump(mode="json"), source_document_text)
     point_id = _insurance_point_id(insurance)
+    payload = _build_payload(insurance.model_dump(mode="json"), source_document_text, point_id)
     await _upsert_point(INSURANCES_COLLECTION, point_id, vector, payload)
     return point_id
 
@@ -175,9 +177,10 @@ async def _upsert_point(
         await client.close()
 
 
-def _build_payload(record: dict[str, Any], source_document_text: str) -> dict[str, Any]:
+def _build_payload(record: dict[str, Any], source_document_text: str, point_id: str) -> dict[str, Any]:
     now = datetime.now(timezone.utc).isoformat()
     return {
+        "id": point_id,
         **record,
         "source_document_text": source_document_text,
         "created_at": now,

--- a/tests/unit/test_vector_database.py
+++ b/tests/unit/test_vector_database.py
@@ -15,8 +15,10 @@ from repositories.vector_database import (
 
 def test_qdrant_collections_preserve_requested_payload_fields() -> None:
     assert set(COLLECTION_SCHEMAS) == {CANDIDATES_COLLECTION, INSURANCES_COLLECTION}
+    assert "id" in COLLECTION_SCHEMAS[CANDIDATES_COLLECTION]["payload_fields"]
     assert "email" in COLLECTION_SCHEMAS[CANDIDATES_COLLECTION]["payload_fields"]
     assert "competences" in COLLECTION_SCHEMAS[CANDIDATES_COLLECTION]["payload_fields"]
+    assert "id" in COLLECTION_SCHEMAS[INSURANCES_COLLECTION]["payload_fields"]
     assert "insurance_number" in COLLECTION_SCHEMAS[INSURANCES_COLLECTION]["payload_fields"]
     assert "coverage_details" in COLLECTION_SCHEMAS[INSURANCES_COLLECTION]["payload_fields"]
     assert "source_document_text" in COLLECTION_SCHEMAS[INSURANCES_COLLECTION]["payload_fields"]


### PR DESCRIPTION
### Motivation
- Persist the deterministic/generated point `id` inside each Qdrant payload so the stored document shape matches the requested table-like schema for `candidates` and `insurances`.
- Make it explicit in collection contracts that `id` is part of the payload to aid downstream consumers and audits.

### Description
- Added `"id"` to `payload_fields` for both `candidates` and `insurances` in `src/repositories/vector_database.py`.
- Compute the point id before building the payload in `save_candidate_record` and `save_insurance_record` and pass it into the payload builder.
- Updated `_build_payload` signature to accept `point_id` and include an `"id": point_id` field in persisted payloads.
- Adjusted the unit test `tests/unit/test_vector_database.py` to assert `id` is present in both collection `payload_fields`.

### Testing
- Ran `python -m compileall src` and the code compiled successfully.
- Ran `pytest -q` and all tests passed (`48 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c37848df883289413c296786c145c)