### PR TITLE
feat: auto-persist CV and insurance uploads to vector database

### DIFF
--- a/src/domain/blueprints.py
+++ b/src/domain/blueprints.py
@@ -114,7 +114,6 @@ DOCUMENT_BLUEPRINT: dict[str, list[str]] = {
         "generate_document_agent_plan",
         "generate_document_tool_spec",
         "resolve_document_processing_flow",
-        "initialize_vector_database",
         "process_candidate_pdf",
         "process_insurance_pdf",
     ],

--- a/src/server.py
+++ b/src/server.py
@@ -8,7 +8,6 @@ from fastmcp.exceptions import ToolError
 from clients.ollama import chat_with_ollama, ollama_health
 from config import SERVICE_NAME
 from logging_config import get_logger
-from repositories.vector_database import init_vector_database
 from services.vector_document_ingestion import (
     process_candidate_pdf_to_vector_db,
     process_insurance_pdf_to_vector_db,
@@ -136,13 +135,6 @@ async def generate_document_tool_spec(capability: str) -> dict[str, Any]:
 async def resolve_document_processing_flow(user_request: str) -> dict[str, Any]:
     logger.info("Tool resolve_document_processing_flow called")
     return resolve_document_processing_flow_tool(user_request)
-
-
-@mcp.tool(description="Create Qdrant vector collections for candidate and insurance records.")
-async def initialize_vector_database() -> dict[str, str]:
-    logger.info("Tool initialize_vector_database called")
-    await init_vector_database()
-    return {"status": "ok", "database": "qdrant", "collections": "candidates, insurances"}
 
 
 @mcp.tool(

--- a/src/services/document_upload.py
+++ b/src/services/document_upload.py
@@ -9,6 +9,10 @@ from starlette.datastructures import UploadFile
 
 from clients.ollama import chat_with_ollama
 from logging_config import get_logger
+from services.vector_document_ingestion import (
+    process_candidate_pdf_to_vector_db,
+    process_insurance_pdf_to_vector_db,
+)
 from tools.document import (
     build_document_prompt,
     extract_pdf_text,
@@ -34,6 +38,7 @@ class PdfUploadRequest(BaseModel):
 
 class PdfUploadResponse(BaseModel):
     response: str
+    persistence: str | None = None
 
 
 async def process_pdf_upload(
@@ -51,11 +56,45 @@ async def process_pdf_upload(
         temp_path = Path(temp_dir) / "upload.pdf"
         await _write_upload_to_file(upload, temp_path)
         document_text = extract_pdf_text(str(temp_path))
+        persistence_result = await _persist_document_if_supported(
+            file_path=str(temp_path),
+            question=request.question,
+            document_text=document_text,
+            max_chars=request.max_chars,
+        )
 
     truncated_text = truncate_document_text(document_text, max_chars=request.max_chars)
     prompt = build_document_prompt(truncated_text, request.question)
     model_result = await chat_with_ollama(prompt)
-    return PdfUploadResponse(response=model_result)
+    return PdfUploadResponse(response=model_result, persistence=persistence_result)
+
+
+async def _persist_document_if_supported(
+    file_path: str,
+    question: str,
+    document_text: str,
+    max_chars: int,
+) -> str | None:
+    doc_type = _infer_document_type(question=question, document_text=document_text)
+    if doc_type == "cv":
+        await process_candidate_pdf_to_vector_db(file_path, max_chars=max_chars)
+        return "saved:candidates"
+    if doc_type == "insurance":
+        await process_insurance_pdf_to_vector_db(file_path, max_chars=max_chars)
+        return "saved:insurances"
+    return None
+
+
+def _infer_document_type(question: str, document_text: str) -> str | None:
+    content = f"{question}\n{document_text}".lower()
+    if any(token in content for token in ("curriculum vitae", "resume", "cv")):
+        return "cv"
+    if any(
+        token in content
+        for token in ("insurance", "policy", "coverage", "premium", "claim")
+    ):
+        return "insurance"
+    return None
 
 
 def _validate_pdf_upload(upload: UploadFile) -> None:

--- a/tests/unit/test_document_upload.py
+++ b/tests/unit/test_document_upload.py
@@ -34,20 +34,36 @@ def test_process_pdf_upload_extracts_uploaded_pdf_and_calls_ollama(
         captured["prompt"] = prompt
         return "PDF answer"
 
+    async def fake_process_candidate_pdf_to_vector_db(
+        file_path: str,
+        max_chars: int = 30000,
+    ) -> dict[str, str]:
+        captured["saved_file_path"] = file_path
+        captured["saved_max_chars"] = str(max_chars)
+        return {"status": "ok"}
+
     monkeypatch.setattr(document_upload, "extract_pdf_text", fake_extract_pdf_text)
     monkeypatch.setattr(document_upload, "chat_with_ollama", fake_chat_with_ollama)
+    monkeypatch.setattr(
+        document_upload,
+        "process_candidate_pdf_to_vector_db",
+        fake_process_candidate_pdf_to_vector_db,
+    )
 
     response = asyncio.run(
         process_pdf_upload(
-            make_upload(),
-            PdfUploadRequest(question="What is this document?", max_chars=1000),
+            make_upload(filename="cv.pdf"),
+            PdfUploadRequest(question="Make a summary of this CV", max_chars=1000),
         )
     )
 
     assert response.response == "PDF answer"
+    assert response.persistence == "saved:candidates"
     assert captured["file_path"].endswith(".pdf")
     assert "Uploaded PDF text" in captured["prompt"]
-    assert "What is this document?" in captured["prompt"]
+    assert "Make a summary of this CV" in captured["prompt"]
+    assert captured["saved_file_path"].endswith(".pdf")
+    assert captured["saved_max_chars"] == "1000"
 
 
 def test_process_pdf_upload_rejects_non_pdf_filename() -> None:
@@ -58,6 +74,34 @@ def test_process_pdf_upload_rejects_non_pdf_filename() -> None:
                 PdfUploadRequest(question="What is this?"),
             )
         )
+
+
+def test_process_pdf_upload_without_cv_or_insurance_skips_persistence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_chat_with_ollama(prompt: str) -> str:
+        return "general answer"
+
+    def fake_extract_pdf_text(file_path: str) -> str:
+        return "Random contract text without known tokens."
+
+    async def fail_if_called(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("vector persistence should not be called")
+
+    monkeypatch.setattr(document_upload, "chat_with_ollama", fake_chat_with_ollama)
+    monkeypatch.setattr(document_upload, "extract_pdf_text", fake_extract_pdf_text)
+    monkeypatch.setattr(document_upload, "process_candidate_pdf_to_vector_db", fail_if_called)
+    monkeypatch.setattr(document_upload, "process_insurance_pdf_to_vector_db", fail_if_called)
+
+    response = asyncio.run(
+        process_pdf_upload(
+            make_upload(),
+            PdfUploadRequest(question="Summarize this document", max_chars=1000),
+        )
+    )
+
+    assert response.response == "general answer"
+    assert response.persistence is None
 
 
 def test_process_pdf_upload_rejects_empty_upload() -> None:
@@ -100,7 +144,7 @@ def test_pdf_upload_endpoint_accepts_multipart_form_data(
     )
 
     assert response.status_code == 200
-    assert response.json() == {"response": "endpoint answer"}
+    assert response.json() == {"response": "endpoint answer", "persistence": None}
     assert captured == {
         "filename": "sample.pdf",
         "question": "Summarize",


### PR DESCRIPTION
### Motivation

- Make database creation implicit and automatic when users upload CVs or insurance PDFs so persistence is part of the upload workflow rather than a separate tool step.  
- Ensure that when a user asks something like "Make a summary of this CV" the service returns the answer and also persists the structured data.  
- Reuse existing vector ingestion logic which already ensures collections are created as-needed during upsert.

### Description

- Added automatic persistence in the PDF upload pipeline by calling `process_candidate_pdf_to_vector_db` or `process_insurance_pdf_to_vector_db` from `process_pdf_upload` when the document is recognized as a CV or an insurance policy.  
- Implemented `_infer_document_type` and `_persist_document_if_supported` helpers in `src/services/document_upload.py` and added an optional `persistence` field to `PdfUploadResponse` to report persistence status (`saved:candidates`, `saved:insurances`, or `None`).  
- Removed the explicit `initialize_vector_database` MCP tool exposure from `src/server.py` and from the `DOCUMENT_BLUEPRINT` tools list in `src/domain/blueprints.py` since initialization happens on-demand via the ingestion services.  
- Updated and added unit tests in `tests/unit/test_document_upload.py` to assert CV persistence, skipping persistence for unrelated documents, and adapted the endpoint test to the new `persistence` response field.

### Testing

- Ran `python -m compileall src` successfully to ensure code compiles.  
- Ran `pytest -q` and all unit tests passed (`49 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eac7121f4832895571e193f50c466)