### PR TITLE
fix: normalize candidate competences list before schema validation

### DIFF
--- a/src/services/vector_document_ingestion.py
+++ b/src/services/vector_document_ingestion.py
@@ -123,9 +123,18 @@ def _parse_json_object(raw_response: str) -> dict[str, Any]:
     return value
 
 
+def _normalize_candidate_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(payload)
+    competences = normalized.get("competences")
+    if isinstance(competences, list):
+        normalized["competences"] = {"items": competences}
+    return normalized
+
+
 def _validate_candidate(payload: dict[str, Any]) -> CandidateRecord:
+    normalized_payload = _normalize_candidate_payload(payload)
     try:
-        return CandidateRecord.model_validate(payload)
+        return CandidateRecord.model_validate(normalized_payload)
     except ValidationError as exc:
         logger.error("Candidate payload validation failed.")
         raise ToolError(

--- a/tests/unit/test_vector_document_ingestion.py
+++ b/tests/unit/test_vector_document_ingestion.py
@@ -14,6 +14,18 @@ def test_parse_json_object_accepts_markdown_fenced_json() -> None:
     }
 
 
+def test_validate_candidate_normalizes_competences_list() -> None:
+    payload = {
+        "first_name": "Ada",
+        "last_name": "Lovelace",
+        "competences": ["Python", "Java"],
+    }
+
+    candidate = vector_document_ingestion._validate_candidate(payload)
+
+    assert candidate.competences == {"items": ["Python", "Java"]}
+
+
 @pytest.mark.anyio
 async def test_process_candidate_pdf_saves_cv_agent_result(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: dict[str, object] = {}


### PR DESCRIPTION
### Motivation
- The CV extraction agent can emit `competences` as a list while the `CandidateRecord` schema expects an object, causing validation failures and `ToolError` during ingestion.
- Normalize the payload before schema validation to make ingestion more robust to model output formats.

### Description
- Added `_normalize_candidate_payload` to `src/services/vector_document_ingestion.py` to convert a `competences` list into `{"items": [...]}` when present.
- Updated `_validate_candidate` to call `_normalize_candidate_payload` before invoking `CandidateRecord.model_validate`.
- Added `test_validate_candidate_normalizes_competences_list` to `tests/unit/test_vector_document_ingestion.py` to verify the normalization behavior.

### Testing
- Ran static compilation with `python -m compileall src` and executed the test suite with `pytest -q`.
- All tests passed: `50 passed in 9.30s`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eb51f87748328a228610dfb7e21d5)