### PR TITLE
feat: add docker compose file with .env-based storage path

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,3 +201,21 @@ Router validation is covered by unit tests and can be checked with:
 python -m compileall src tests
 pytest -q
 ```
+
+
+## Docker Compose (Qdrant storage path from `.env`)
+
+A Docker Compose file is included at the repository root and reads the Qdrant host storage path from `.env` using `QDRANT_STORAGE_PATH`.
+
+Current `.env` example:
+
+```bash
+QDRANT_STORAGE_PATH=./qdrant_storage
+```
+
+Start Qdrant with:
+
+```bash
+docker compose up -d qdrant
+```
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.9"
+
+services:
+  qdrant:
+    image: qdrant/qdrant:latest
+    container_name: smart-ide-qdrant
+    ports:
+      - "6333:6333"
+      - "6334:6334"
+    volumes:
+      - ${QDRANT_STORAGE_PATH:-./qdrant_storage}:/qdrant/storage


### PR DESCRIPTION
### Motivation

- Provide a simple, environment-driven way to run Qdrant locally with persisted host storage configurable from `.env` for easier local development and multi-machine portability.

### Description

- Add a root `docker-compose.yml` that defines a `qdrant` service with ports `6333` and `6334` and a host volume mapped using `${QDRANT_STORAGE_PATH:-./qdrant_storage}`.
- Update `README.md` with a `Docker Compose` section documenting the `QDRANT_STORAGE_PATH` `.env` variable and the startup command `docker compose up -d qdrant`.

### Testing

- Run `python -m compileall src` to ensure source compiles; this completed successfully.
- Run `pytest -q` to validate the test suite; all tests passed (`42 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1562d1cc688328b2a1664ffc2fbf07)