### PR TITLE
feat(documents): persist classified PDF CV/insurance data to Qdrant collections

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -10,3 +10,11 @@ LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 LOG_FILE = os.getenv("LOG_FILE", "smart-ide-services.log")
 LOG_MAX_BYTES = int(os.getenv("LOG_MAX_BYTES", "1048576"))
 LOG_BACKUP_COUNT = int(os.getenv("LOG_BACKUP_COUNT", "5"))
+QDRANT_URL = os.getenv("QDRANT_URL", "http://127.0.0.1:6333")
+QDRANT_TIMEOUT_SECONDS = float(os.getenv("QDRANT_TIMEOUT_SECONDS", "10"))
+QDRANT_CANDIDATES_COLLECTION = os.getenv(
+    "QDRANT_CANDIDATES_COLLECTION", "candidates"
+)
+QDRANT_INSURANCES_COLLECTION = os.getenv(
+    "QDRANT_INSURANCES_COLLECTION", "insurances"
+)

--- a/src/services/document_persistence.py
+++ b/src/services/document_persistence.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import hashlib
+import re
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+from config import (
+    QDRANT_CANDIDATES_COLLECTION,
+    QDRANT_INSURANCES_COLLECTION,
+    QDRANT_TIMEOUT_SECONDS,
+    QDRANT_URL,
+)
+
+
+def infer_pdf_domain(document_text: str, question: str) -> str:
+    corpus = f"{question}\n{document_text}".lower()
+    insurance_keywords = (
+        "policy",
+        "insurance",
+        "coverage",
+        "premium",
+        "beneficiary",
+        "claim",
+        "provider",
+    )
+    cv_keywords = (
+        "curriculum vitae",
+        "resume",
+        "work experience",
+        "education",
+        "skills",
+        "certification",
+    )
+    if any(keyword in corpus for keyword in insurance_keywords):
+        return "insurance"
+    if any(keyword in corpus for keyword in cv_keywords):
+        return "cv"
+    return "other"
+
+
+def build_candidate_payload(document_text: str) -> dict[str, Any]:
+    email = _extract_first(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}", document_text)
+    phone = _extract_first(r"\+?[0-9][0-9\s().-]{6,}[0-9]", document_text)
+    lines = [line.strip() for line in document_text.splitlines() if line.strip()]
+    full_name = lines[0] if lines else ""
+    first_name, last_name = _split_name(full_name)
+
+    return {
+        "id": str(uuid.uuid4()),
+        "first_name": first_name,
+        "last_name": last_name,
+        "email": email,
+        "phone": phone,
+        "seniority": _detect_seniority(document_text),
+        "competences": {},
+        "previous_works": [],
+        "education": [],
+        "raw_text": document_text,
+        "created_at": _utc_timestamp(),
+        "updated_at": _utc_timestamp(),
+    }
+
+
+def build_insurance_payload(document_text: str) -> dict[str, Any]:
+    policy_number = _extract_first(
+        r"(?:policy|insurance)\s*(?:number|no\.?|#)\s*[:\-]?\s*([A-Za-z0-9-]+)",
+        document_text,
+        capture_group=1,
+    )
+    provider_name = _extract_first(
+        r"(?:provider|insurer|company)\s*[:\-]\s*([^\n]+)",
+        document_text,
+        capture_group=1,
+    ) or "unknown"
+
+    return {
+        "id": str(uuid.uuid4()),
+        "insurance_number": policy_number or f"unknown-{uuid.uuid4().hex[:12]}",
+        "insurance_type": _detect_insurance_type(document_text),
+        "provider_name": provider_name.strip(),
+        "status": _detect_insurance_status(document_text),
+        "coverage_details": {},
+        "documents": [],
+        "raw_text": document_text,
+        "created_at": _utc_timestamp(),
+        "updated_at": _utc_timestamp(),
+    }
+
+
+async def persist_document_if_supported(document_text: str, question: str) -> str:
+    domain = infer_pdf_domain(document_text, question)
+    if domain == "cv":
+        await _upsert_payload(
+            QDRANT_CANDIDATES_COLLECTION,
+            build_candidate_payload(document_text),
+        )
+    elif domain == "insurance":
+        await _upsert_payload(
+            QDRANT_INSURANCES_COLLECTION,
+            build_insurance_payload(document_text),
+        )
+    return domain
+
+
+async def _upsert_payload(collection_name: str, payload: dict[str, Any]) -> None:
+    point_id = _qdrant_point_id(payload["id"])
+    body = {
+        "points": [
+            {
+                "id": point_id,
+                "vector": [0.0],
+                "payload": payload,
+            }
+        ]
+    }
+    timeout = httpx.Timeout(QDRANT_TIMEOUT_SECONDS)
+    async with httpx.AsyncClient(base_url=QDRANT_URL, timeout=timeout) as client:
+        await client.put(f"/collections/{collection_name}/points", json=body)
+
+
+def _qdrant_point_id(value: str) -> int:
+    digest = hashlib.sha1(value.encode("utf-8")).hexdigest()[:16]
+    return int(digest, 16)
+
+
+def _extract_first(pattern: str, text: str, capture_group: int = 0) -> str | None:
+    match = re.search(pattern, text, flags=re.IGNORECASE)
+    if not match:
+        return None
+    return match.group(capture_group).strip()
+
+
+def _split_name(full_name: str) -> tuple[str, str]:
+    parts = [part for part in full_name.split() if part]
+    if len(parts) >= 2:
+        return parts[0], " ".join(parts[1:])
+    if len(parts) == 1:
+        return parts[0], ""
+    return "unknown", "unknown"
+
+
+def _detect_seniority(text: str) -> str:
+    lowered = text.lower()
+    for level in ("lead", "senior", "mid", "junior"):
+        if level in lowered:
+            return level
+    return "unknown"
+
+
+def _detect_insurance_type(text: str) -> str:
+    lowered = text.lower()
+    for insurance_type in ("health", "car", "life", "travel", "home"):
+        if insurance_type in lowered:
+            return insurance_type
+    return "unknown"
+
+
+def _detect_insurance_status(text: str) -> str:
+    lowered = text.lower()
+    for status in ("active", "expired", "suspended", "cancelled"):
+        if status in lowered:
+            return status
+    return "unknown"
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/src/services/document_upload.py
+++ b/src/services/document_upload.py
@@ -13,6 +13,7 @@ from tools.document import (
     extract_pdf_text,
     truncate_document_text,
 )
+from services.document_persistence import persist_document_if_supported
 
 
 class PdfUploadRequest(BaseModel):
@@ -52,6 +53,7 @@ async def process_pdf_upload(
     truncated_text = truncate_document_text(document_text, max_chars=request.max_chars)
     prompt = build_document_prompt(truncated_text, request.question)
     model_result = await chat_with_ollama(prompt)
+    await persist_document_if_supported(document_text=truncated_text, question=request.question)
     return PdfUploadResponse(response=model_result)
 
 

--- a/tests/unit/test_document_persistence.py
+++ b/tests/unit/test_document_persistence.py
@@ -1,0 +1,37 @@
+from services.document_persistence import (
+    build_candidate_payload,
+    build_insurance_payload,
+    infer_pdf_domain,
+)
+
+
+def test_infer_pdf_domain_detects_cv() -> None:
+    assert infer_pdf_domain("Work experience and education", "Summarize this CV") == "cv"
+
+
+def test_infer_pdf_domain_detects_insurance() -> None:
+    assert infer_pdf_domain("Policy number 123", "Explain insurance coverage") == "insurance"
+
+
+def test_infer_pdf_domain_returns_other_for_unsupported_documents() -> None:
+    assert infer_pdf_domain("Quarterly revenue and EBITDA", "Summarize this report") == "other"
+
+
+def test_build_candidate_payload_extracts_contact_fields() -> None:
+    payload = build_candidate_payload("Jane Doe\nEmail: jane@example.com\nPhone: +1 202 555 0110\nSenior engineer")
+
+    assert payload["first_name"] == "Jane"
+    assert payload["last_name"] == "Doe"
+    assert payload["email"] == "jane@example.com"
+    assert payload["seniority"] == "senior"
+
+
+def test_build_insurance_payload_extracts_policy_fields() -> None:
+    payload = build_insurance_payload(
+        "Policy Number: POL-001\nProvider: Acme Insurance\nStatus: active\nHealth coverage"
+    )
+
+    assert payload["insurance_number"] == "POL-001"
+    assert payload["provider_name"] == "Acme Insurance"
+    assert payload["status"] == "active"
+    assert payload["insurance_type"] == "health"

--- a/tests/unit/test_document_upload.py
+++ b/tests/unit/test_document_upload.py
@@ -34,8 +34,18 @@ def test_process_pdf_upload_extracts_uploaded_pdf_and_calls_ollama(
         captured["prompt"] = prompt
         return "PDF answer"
 
+    async def fake_persist_document_if_supported(document_text: str, question: str) -> str:
+        captured["persist_document_text"] = document_text
+        captured["persist_question"] = question
+        return "cv"
+
     monkeypatch.setattr(document_upload, "extract_pdf_text", fake_extract_pdf_text)
     monkeypatch.setattr(document_upload, "chat_with_ollama", fake_chat_with_ollama)
+    monkeypatch.setattr(
+        document_upload,
+        "persist_document_if_supported",
+        fake_persist_document_if_supported,
+    )
 
     response = asyncio.run(
         process_pdf_upload(
@@ -48,6 +58,8 @@ def test_process_pdf_upload_extracts_uploaded_pdf_and_calls_ollama(
     assert captured["file_path"].endswith(".pdf")
     assert "Uploaded PDF text" in captured["prompt"]
     assert "What is this document?" in captured["prompt"]
+    assert captured["persist_document_text"] == "Uploaded PDF text"
+    assert captured["persist_question"] == "What is this document?"
 
 
 def test_process_pdf_upload_rejects_non_pdf_filename() -> None:


### PR DESCRIPTION
### Motivation
- Allow the service to persist structured data when uploaded PDFs are CVs or insurance policies while keeping non-matching documents out of storage.
- Provide basic, traceable payloads aligned with candidate/insurance schemas so downstream tooling can iterate on richer extraction and indexing.

### Description
- Added `src/services/document_persistence.py` which classifies extracted PDF text as `cv`, `insurance`, or `other`, builds candidate/insurance payloads, and upserts them to Qdrant collections via HTTP when applicable.
- Wired persistence into the PDF upload flow in `src/services/document_upload.py` so the model answer is returned to the user and persistence runs afterward using the truncated extracted text.
- Introduced Qdrant configuration knobs in `src/config.py` (`QDRANT_URL`, `QDRANT_TIMEOUT_SECONDS`, `QDRANT_CANDIDATES_COLLECTION`, `QDRANT_INSURANCES_COLLECTION`).
- Added unit tests `tests/unit/test_document_persistence.py` for domain detection and payload mapping and updated `tests/unit/test_document_upload.py` to assert persistence is invoked with the extracted text and question.

### Testing
- Ran `python -m compileall src` which completed successfully.
- Ran `pytest -q` which passed all tests (`47 passed`) in CI-like local run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15739dce1883288d7073bb5b97d447)