### PR TITLE
fix: avoid duplicate document persistence

### DIFF
--- a/src/services/document_persistence.py
+++ b/src/services/document_persistence.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import hashlib
 import re
-import uuid
 from datetime import datetime, timezone
 from typing import Any
 
@@ -43,14 +42,18 @@ def infer_pdf_domain(document_text: str, question: str) -> str:
 
 
 def build_candidate_payload(document_text: str) -> dict[str, Any]:
-    email = _extract_first(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}", document_text)
+    document_hash = _document_hash(document_text)
+    email = _extract_first(
+        r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}", document_text
+    )
     phone = _extract_first(r"\+?[0-9][0-9\s().-]{6,}[0-9]", document_text)
     lines = [line.strip() for line in document_text.splitlines() if line.strip()]
     full_name = lines[0] if lines else ""
     first_name, last_name = _split_name(full_name)
 
     return {
-        "id": str(uuid.uuid4()),
+        "id": f"candidate-{document_hash}",
+        "document_hash": document_hash,
         "first_name": first_name,
         "last_name": last_name,
         "email": email,
@@ -66,20 +69,25 @@ def build_candidate_payload(document_text: str) -> dict[str, Any]:
 
 
 def build_insurance_payload(document_text: str) -> dict[str, Any]:
+    document_hash = _document_hash(document_text)
     policy_number = _extract_first(
         r"(?:policy|insurance)\s*(?:number|no\.?|#)\s*[:\-]?\s*([A-Za-z0-9-]+)",
         document_text,
         capture_group=1,
     )
-    provider_name = _extract_first(
-        r"(?:provider|insurer|company)\s*[:\-]\s*([^\n]+)",
-        document_text,
-        capture_group=1,
-    ) or "unknown"
+    provider_name = (
+        _extract_first(
+            r"(?:provider|insurer|company)\s*[:\-]\s*([^\n]+)",
+            document_text,
+            capture_group=1,
+        )
+        or "unknown"
+    )
 
     return {
-        "id": str(uuid.uuid4()),
-        "insurance_number": policy_number or f"unknown-{uuid.uuid4().hex[:12]}",
+        "id": f"insurance-{document_hash}",
+        "document_hash": document_hash,
+        "insurance_number": policy_number or f"unknown-{document_hash[:12]}",
         "insurance_type": _detect_insurance_type(document_text),
         "provider_name": provider_name.strip(),
         "status": _detect_insurance_status(document_text),
@@ -94,16 +102,48 @@ def build_insurance_payload(document_text: str) -> dict[str, Any]:
 async def persist_document_if_supported(document_text: str, question: str) -> str:
     domain = infer_pdf_domain(document_text, question)
     if domain == "cv":
-        await _upsert_payload(
-            QDRANT_CANDIDATES_COLLECTION,
-            build_candidate_payload(document_text),
-        )
+        payload = build_candidate_payload(document_text)
+        await _upsert_payload_if_new(QDRANT_CANDIDATES_COLLECTION, payload)
     elif domain == "insurance":
-        await _upsert_payload(
-            QDRANT_INSURANCES_COLLECTION,
-            build_insurance_payload(document_text),
-        )
+        payload = build_insurance_payload(document_text)
+        await _upsert_payload_if_new(QDRANT_INSURANCES_COLLECTION, payload)
     return domain
+
+
+async def _upsert_payload_if_new(collection_name: str, payload: dict[str, Any]) -> None:
+    if await _document_exists(collection_name, payload):
+        return
+
+    await _upsert_payload(collection_name, payload)
+
+
+async def _document_exists(collection_name: str, payload: dict[str, Any]) -> bool:
+    body = {
+        "filter": {
+            "should": [
+                {
+                    "key": "document_hash",
+                    "match": {"value": payload["document_hash"]},
+                },
+                {
+                    "key": "raw_text",
+                    "match": {"value": payload["raw_text"]},
+                },
+            ]
+        },
+        "limit": 1,
+        "with_payload": False,
+        "with_vector": False,
+    }
+    timeout = httpx.Timeout(QDRANT_TIMEOUT_SECONDS)
+    async with httpx.AsyncClient(base_url=QDRANT_URL, timeout=timeout) as client:
+        response = await client.post(
+            f"/collections/{collection_name}/points/scroll", json=body
+        )
+        response.raise_for_status()
+
+    points = response.json().get("result", {}).get("points", [])
+    return bool(points)
 
 
 async def _upsert_payload(collection_name: str, payload: dict[str, Any]) -> None:
@@ -125,6 +165,13 @@ async def _upsert_payload(collection_name: str, payload: dict[str, Any]) -> None
 def _qdrant_point_id(value: str) -> int:
     digest = hashlib.sha1(value.encode("utf-8")).hexdigest()[:16]
     return int(digest, 16)
+
+
+def _document_hash(document_text: str) -> str:
+    normalized_text = "\n".join(
+        line.strip() for line in document_text.splitlines() if line.strip()
+    )
+    return hashlib.sha256(normalized_text.encode("utf-8")).hexdigest()
 
 
 def _extract_first(pattern: str, text: str, capture_group: int = 0) -> str | None:

--- a/tests/unit/test_document_persistence.py
+++ b/tests/unit/test_document_persistence.py
@@ -1,24 +1,40 @@
+import asyncio
+
+import pytest
+
+from services import document_persistence
 from services.document_persistence import (
     build_candidate_payload,
     build_insurance_payload,
     infer_pdf_domain,
+    persist_document_if_supported,
 )
 
 
 def test_infer_pdf_domain_detects_cv() -> None:
-    assert infer_pdf_domain("Work experience and education", "Summarize this CV") == "cv"
+    assert (
+        infer_pdf_domain("Work experience and education", "Summarize this CV") == "cv"
+    )
 
 
 def test_infer_pdf_domain_detects_insurance() -> None:
-    assert infer_pdf_domain("Policy number 123", "Explain insurance coverage") == "insurance"
+    assert (
+        infer_pdf_domain("Policy number 123", "Explain insurance coverage")
+        == "insurance"
+    )
 
 
 def test_infer_pdf_domain_returns_other_for_unsupported_documents() -> None:
-    assert infer_pdf_domain("Quarterly revenue and EBITDA", "Summarize this report") == "other"
+    assert (
+        infer_pdf_domain("Quarterly revenue and EBITDA", "Summarize this report")
+        == "other"
+    )
 
 
 def test_build_candidate_payload_extracts_contact_fields() -> None:
-    payload = build_candidate_payload("Jane Doe\nEmail: jane@example.com\nPhone: +1 202 555 0110\nSenior engineer")
+    payload = build_candidate_payload(
+        "Jane Doe\nEmail: jane@example.com\nPhone: +1 202 555 0110\nSenior engineer"
+    )
 
     assert payload["first_name"] == "Jane"
     assert payload["last_name"] == "Doe"
@@ -35,3 +51,100 @@ def test_build_insurance_payload_extracts_policy_fields() -> None:
     assert payload["provider_name"] == "Acme Insurance"
     assert payload["status"] == "active"
     assert payload["insurance_type"] == "health"
+
+
+def test_build_candidate_payload_uses_stable_document_identity() -> None:
+    first_payload = build_candidate_payload(
+        "Jane Doe\nEmail: jane@example.com\nSenior engineer"
+    )
+    second_payload = build_candidate_payload(
+        " Jane Doe \n\n Email: jane@example.com \n Senior engineer "
+    )
+
+    assert first_payload["document_hash"] == second_payload["document_hash"]
+    assert first_payload["id"] == second_payload["id"]
+
+
+def test_build_insurance_payload_uses_stable_unknown_policy_number() -> None:
+    first_payload = build_insurance_payload("Provider: Acme Insurance\nHealth coverage")
+    second_payload = build_insurance_payload(
+        " Provider: Acme Insurance \n Health coverage "
+    )
+
+    assert first_payload["document_hash"] == second_payload["document_hash"]
+    assert first_payload["insurance_number"] == second_payload["insurance_number"]
+
+
+def test_persist_document_if_supported_skips_existing_cv(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: dict[str, object] = {}
+
+    async def fake_document_exists(
+        collection_name: str, payload: dict[str, object]
+    ) -> bool:
+        calls["exists_collection"] = collection_name
+        calls["exists_hash"] = payload["document_hash"]
+        calls["exists_raw_text"] = payload["raw_text"]
+        return True
+
+    async def fake_upsert_payload(
+        collection_name: str, payload: dict[str, object]
+    ) -> None:
+        calls["upsert_collection"] = collection_name
+
+    monkeypatch.setattr(document_persistence, "_document_exists", fake_document_exists)
+    monkeypatch.setattr(document_persistence, "_upsert_payload", fake_upsert_payload)
+
+    domain = asyncio.run(
+        persist_document_if_supported(
+            "Jane Doe\nEmail: jane@example.com\nWork experience",
+            "Read this CV",
+        )
+    )
+
+    assert domain == "cv"
+    assert (
+        calls["exists_collection"] == document_persistence.QDRANT_CANDIDATES_COLLECTION
+    )
+    assert "exists_hash" in calls
+    assert "upsert_collection" not in calls
+
+
+def test_persist_document_if_supported_saves_new_insurance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: dict[str, object] = {}
+
+    async def fake_document_exists(
+        collection_name: str, payload: dict[str, object]
+    ) -> bool:
+        calls["exists_collection"] = collection_name
+        calls["exists_hash"] = payload["document_hash"]
+        calls["exists_raw_text"] = payload["raw_text"]
+        return False
+
+    async def fake_upsert_payload(
+        collection_name: str, payload: dict[str, object]
+    ) -> None:
+        calls["upsert_collection"] = collection_name
+        calls["upsert_hash"] = payload["document_hash"]
+
+    monkeypatch.setattr(document_persistence, "_document_exists", fake_document_exists)
+    monkeypatch.setattr(document_persistence, "_upsert_payload", fake_upsert_payload)
+
+    domain = asyncio.run(
+        persist_document_if_supported(
+            "Policy Number: POL-001\nProvider: Acme Insurance\nStatus: active",
+            "Explain insurance coverage",
+        )
+    )
+
+    assert domain == "insurance"
+    assert (
+        calls["exists_collection"] == document_persistence.QDRANT_INSURANCES_COLLECTION
+    )
+    assert (
+        calls["upsert_collection"] == document_persistence.QDRANT_INSURANCES_COLLECTION
+    )
+    assert calls["upsert_hash"] == calls["exists_hash"]


### PR DESCRIPTION
### Motivation
- Prevent saving the same CV or insurance document multiple times when re-uploaded by introducing a deterministic document identity and existence check before persisting.

### Description
- Compute a normalized SHA-256 `document_hash` and use it to produce stable payload `id` values for CVs and insurance payloads via `build_candidate_payload` and `build_insurance_payload` (new `_document_hash`).
- Change `persist_document_if_supported` to call a new `_upsert_payload_if_new` helper that checks Qdrant for an existing record before upserting by calling `_document_exists` which queries `points/scroll` matching `document_hash` or legacy `raw_text`.
- Keep the actual upsert behavior in `_upsert_payload` and derive Qdrant point ids from stable payload ids via `_qdrant_point_id`.
- Add unit tests covering stable document identity, skipping persistence when a CV already exists, and saving new insurance documents; update tests to exercise the new existence-checking flow.

### Testing
- Ran `python -m compileall src` which completed successfully.
- Ran `pytest` which passed all tests: `51 passed` with one existing Starlette deprecation warning.
- Additional unit tests were added/updated in `tests/unit/test_document_persistence.py` and all test assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d2ae2a39c8328bd935681cd485957)