### PR TITLE
refactor: validate vector DB metadata from payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ curl -X POST "http://127.0.0.1:8000/api/documents/pdf" \
 
 Successful responses contain only the Ollama answer as `{"response":"result based on the uploaded PDF"}`.
 
-When the uploaded text is classified as a CV/resume or insurance policy, the service also upserts a Qdrant payload in the configured `candidates` or `insurances` collection. In addition to `raw_text`, the persistence layer maps detected CV sections into candidate fields such as `education`, `previous_works`, and `competences`, and maps detected insurance policy facts into `coverage_details`, `documents`, `provider_name`, `insurance_number`, `insurance_type`, and `status`. Missing fields remain empty or `unknown` instead of being guessed.
+When the uploaded text is classified as a CV/resume or insurance policy, the service also upserts vector DB records in the configured `candidates` or `insurances` collection. The vector DB save workflow receives an already-extracted payload, validates it against metadata schemas, optionally splits long `raw_text` into chunk records, and persists the resulting metadata without assigning semantic defaults such as candidate names, statuses, insurance types, or skills inside the save layer. Missing optional metadata fields remain `None` or empty lists unless the extracted payload itself contains a value.
 
 ### POST `/api/prompts/execute`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.10"
 dependencies = [
   "fastmcp>=2.4,<4",
   "httpx>=0.27.0",
+  "pydantic>=2,<3",
   "python-multipart>=0.0.9,<1",
   "starlette>=0.37.0,<2",
   "uvicorn[standard]>=0.30.0,<1",

--- a/src/services/document_persistence.py
+++ b/src/services/document_persistence.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 import httpx
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
 from config import (
     QDRANT_CANDIDATES_COLLECTION,
@@ -13,6 +14,69 @@ from config import (
     QDRANT_TIMEOUT_SECONDS,
     QDRANT_URL,
 )
+
+
+VECTOR_DB_CHUNK_SIZE = 4000
+
+
+class VectorDbMetadataError(ValueError):
+    """Raised when extracted metadata cannot be persisted to the vector DB."""
+
+
+class CandidateVectorMetadata(BaseModel):
+    """Validated candidate metadata produced by the extraction layer."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str = Field(..., min_length=1)
+    document_hash: str | None = None
+    first_name: str | None = None
+    last_name: str | None = None
+    email: str | None = None
+    phone: str | None = None
+    seniority: str | None = None
+    competences: dict[str, Any] | None = None
+    previous_works: list[dict[str, Any]] = Field(default_factory=list)
+    education: list[str] = Field(default_factory=list)
+    certification: list[str] = Field(default_factory=list)
+    languages: list[str] = Field(default_factory=list)
+    raw_text: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class InsuranceVectorMetadata(BaseModel):
+    """Validated insurance metadata produced by the extraction layer."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str = Field(..., min_length=1)
+    document_hash: str | None = None
+    insurance_number: str | None = None
+    insurance_type: str | None = None
+    provider_name: str | None = None
+    status: str | None = None
+    coverage_details: dict[str, Any] | None = None
+    documents: list[dict[str, Any]] = Field(default_factory=list)
+    raw_text: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class VectorDbRecord(BaseModel):
+    """A validated vector DB record ready to upsert."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: int
+    vector: list[float] = Field(min_length=1)
+    payload: dict[str, Any]
+
+    @field_validator("payload")
+    @classmethod
+    def payload_values_must_be_supported(cls, value: dict[str, Any]) -> dict[str, Any]:
+        _validate_metadata_values(value)
+        return value
 
 
 def infer_pdf_domain(document_text: str, question: str) -> str:
@@ -97,25 +161,75 @@ def build_insurance_payload(document_text: str) -> dict[str, Any]:
 async def persist_document_if_supported(document_text: str, question: str) -> str:
     domain = infer_pdf_domain(document_text, question)
     if domain == "cv":
-        payload = build_candidate_payload(document_text)
-        await _upsert_payload(QDRANT_CANDIDATES_COLLECTION, payload)
+        extracted_payload = build_candidate_payload(document_text)
+        await _upsert_payload(QDRANT_CANDIDATES_COLLECTION, extracted_payload)
     elif domain == "insurance":
-        payload = build_insurance_payload(document_text)
-        await _upsert_payload(QDRANT_INSURANCES_COLLECTION, payload)
+        extracted_payload = build_insurance_payload(document_text)
+        await _upsert_payload(QDRANT_INSURANCES_COLLECTION, extracted_payload)
     return domain
 
 
+async def persist_extracted_payload(
+    collection_name: str,
+    extracted_payload: dict[str, Any],
+    *,
+    metadata_kind: str | None = None,
+) -> None:
+    """Persist already-extracted LLM payload metadata to the vector DB.
+
+    The vector DB workflow validates and persists the metadata it receives. It does
+    not infer or hardcode semantic metadata such as status, skills, candidate names,
+    document types, or insurance types.
+    """
+    records = build_vector_db_records(extracted_payload, metadata_kind=metadata_kind)
+    await _upsert_records(collection_name, records)
+
+
+def build_vector_db_records(
+    extracted_payload: dict[str, Any],
+    *,
+    metadata_kind: str | None = None,
+) -> list[VectorDbRecord]:
+    metadata = build_vector_db_metadata(
+        extracted_payload, metadata_kind=metadata_kind
+    )
+    chunks = _split_embedding_text(_embedding_text_from_payload(metadata))
+    return [
+        VectorDbRecord(
+            id=_qdrant_point_id(
+                _chunk_record_id(str(metadata["id"]), index, len(chunks))
+            ),
+            vector=_embedding_vector_for_text(chunk),
+            payload=_metadata_for_chunk(metadata, index, len(chunks)),
+        )
+        for index, chunk in enumerate(chunks)
+    ]
+
+
+def build_vector_db_metadata(
+    extracted_payload: dict[str, Any],
+    *,
+    metadata_kind: str | None = None,
+) -> dict[str, Any]:
+    schema = _metadata_schema(metadata_kind)
+    try:
+        metadata_model = schema.model_validate(extracted_payload)
+    except ValidationError as exc:
+        raise VectorDbMetadataError(str(exc)) from exc
+
+    metadata = metadata_model.model_dump(mode="json")
+    _validate_metadata_values(metadata)
+    return metadata
+
+
 async def _upsert_payload(collection_name: str, payload: dict[str, Any]) -> None:
-    point_id = _qdrant_point_id(payload["id"])
-    body = {
-        "points": [
-            {
-                "id": point_id,
-                "vector": [0.0],
-                "payload": payload,
-            }
-        ]
-    }
+    await persist_extracted_payload(collection_name, payload)
+
+
+async def _upsert_records(
+    collection_name: str, records: list[VectorDbRecord]
+) -> None:
+    body = {"points": [record.model_dump(mode="json") for record in records]}
     timeout = httpx.Timeout(QDRANT_TIMEOUT_SECONDS)
     async with httpx.AsyncClient(base_url=QDRANT_URL, timeout=timeout) as client:
         await client.put(f"/collections/{collection_name}/points", json=body)
@@ -737,3 +851,79 @@ def _detect_insurance_status(text: str) -> str:
 
 def _utc_timestamp() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _metadata_schema(metadata_kind: str | None) -> type[BaseModel]:
+    if metadata_kind == "candidate":
+        return CandidateVectorMetadata
+    if metadata_kind == "insurance":
+        return InsuranceVectorMetadata
+    return GenericVectorMetadata
+
+
+class GenericVectorMetadata(BaseModel):
+    """Validated generic metadata produced by the extraction layer."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str = Field(..., min_length=1)
+    raw_text: str | None = None
+
+
+def _embedding_text_from_payload(metadata: dict[str, Any]) -> str:
+    raw_text = metadata.get("raw_text")
+    if isinstance(raw_text, str) and raw_text:
+        return raw_text
+    return " ".join(str(value) for value in metadata.values() if value is not None)
+
+
+def _split_embedding_text(text: str) -> list[str]:
+    if not text:
+        return [""]
+    return [
+        text[index : index + VECTOR_DB_CHUNK_SIZE]
+        for index in range(0, len(text), VECTOR_DB_CHUNK_SIZE)
+    ]
+
+
+def _chunk_record_id(base_id: str, chunk_index: int, chunk_count: int) -> str:
+    if chunk_count == 1:
+        return base_id
+    return f"{base_id}:chunk-{chunk_index}"
+
+
+def _metadata_for_chunk(
+    metadata: dict[str, Any], chunk_index: int, chunk_count: int
+) -> dict[str, Any]:
+    chunk_metadata = dict(metadata)
+    if chunk_count > 1:
+        chunk_metadata["chunk_index"] = chunk_index
+        chunk_metadata["chunk_count"] = chunk_count
+    return chunk_metadata
+
+
+def _embedding_vector_for_text(_text: str) -> list[float]:
+    return [0.0]
+
+
+def _validate_metadata_values(metadata: dict[str, Any]) -> None:
+    for key, value in metadata.items():
+        if not isinstance(key, str) or not key:
+            raise VectorDbMetadataError("metadata keys must be non-empty strings")
+        _validate_metadata_value(key, value)
+
+
+def _validate_metadata_value(key: str, value: Any) -> None:
+    if value is None or isinstance(value, str | int | float | bool):
+        return
+    if isinstance(value, list):
+        for item in value:
+            _validate_metadata_value(key, item)
+        return
+    if isinstance(value, dict):
+        _validate_metadata_values(value)
+        return
+    raise VectorDbMetadataError(
+        f"metadata field '{key}' has unsupported value type "
+        f"{type(value).__name__}"
+    )

--- a/tests/unit/test_document_persistence.py
+++ b/tests/unit/test_document_persistence.py
@@ -6,8 +6,11 @@ from services import document_persistence
 from services.document_persistence import (
     build_candidate_payload,
     build_insurance_payload,
+    build_vector_db_metadata,
+    build_vector_db_records,
     infer_pdf_domain,
     persist_document_if_supported,
+    persist_extracted_payload,
 )
 
 
@@ -264,3 +267,135 @@ def test_persist_document_if_supported_saves_new_insurance(
         calls["upsert_collection"] == document_persistence.QDRANT_INSURANCES_COLLECTION
     )
     assert "upsert_hash" in calls
+
+
+def test_build_vector_metadata_uses_extracted_insurance_payload_values() -> None:
+    payload = {
+        "id": "insurance-ai-1",
+        "insurance_number": "AI-POL-999",
+        "insurance_type": "dental",
+        "provider_name": "Payload Mutual",
+        "status": "pending_review",
+        "coverage_details": {"coverages": ["orthodontics"]},
+        "documents": [{"type": "policy", "reference": "DOC-7"}],
+        "raw_text": "Extracted policy text",
+    }
+
+    metadata = build_vector_db_metadata(payload, metadata_kind="insurance")
+
+    assert metadata["insurance_number"] == "AI-POL-999"
+    assert metadata["insurance_type"] == "dental"
+    assert metadata["provider_name"] == "Payload Mutual"
+    assert metadata["status"] == "pending_review"
+    assert metadata["coverage_details"] == {"coverages": ["orthodontics"]}
+    assert metadata["documents"] == [{"type": "policy", "reference": "DOC-7"}]
+
+
+def test_build_vector_metadata_allows_missing_optional_insurance_fields() -> None:
+    metadata = build_vector_db_metadata(
+        {"id": "insurance-ai-2", "raw_text": "No optional values extracted"},
+        metadata_kind="insurance",
+    )
+
+    assert metadata["insurance_number"] is None
+    assert metadata["insurance_type"] is None
+    assert metadata["provider_name"] is None
+    assert metadata["status"] is None
+    assert metadata["coverage_details"] is None
+    assert metadata["documents"] == []
+
+
+def test_build_vector_metadata_uses_extracted_candidate_payload_values() -> None:
+    payload = {
+        "id": "candidate-ai-1",
+        "first_name": "Amina",
+        "last_name": "Payload",
+        "seniority": "principal",
+        "competences": {"technical": ["rust", "python"]},
+        "education": ["MSc Computer Science"],
+        "certification": ["Kubernetes Administrator"],
+        "languages": ["English", "French"],
+        "raw_text": "Candidate profile",
+    }
+
+    metadata = build_vector_db_metadata(payload, metadata_kind="candidate")
+
+    assert metadata["first_name"] == "Amina"
+    assert metadata["last_name"] == "Payload"
+    assert metadata["seniority"] == "principal"
+    assert metadata["competences"] == {"technical": ["rust", "python"]}
+    assert metadata["education"] == ["MSc Computer Science"]
+    assert metadata["certification"] == ["Kubernetes Administrator"]
+    assert metadata["languages"] == ["English", "French"]
+
+
+def test_build_vector_metadata_allows_missing_optional_candidate_fields() -> None:
+    metadata = build_vector_db_metadata(
+        {"id": "candidate-ai-2", "raw_text": "No optional values extracted"},
+        metadata_kind="candidate",
+    )
+
+    assert metadata["first_name"] is None
+    assert metadata["last_name"] is None
+    assert metadata["email"] is None
+    assert metadata["phone"] is None
+    assert metadata["seniority"] is None
+    assert metadata["competences"] is None
+    assert metadata["previous_works"] == []
+    assert metadata["education"] == []
+    assert metadata["certification"] == []
+    assert metadata["languages"] == []
+
+
+def test_build_vector_records_chunks_embedding_text_without_changing_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(document_persistence, "VECTOR_DB_CHUNK_SIZE", 5)
+    records = build_vector_db_records(
+        {
+            "id": "candidate-ai-3",
+            "first_name": "Chunky",
+            "raw_text": "abcdefghijk",
+        },
+        metadata_kind="candidate",
+    )
+
+    assert len(records) == 3
+    assert [record.payload["first_name"] for record in records] == [
+        "Chunky",
+        "Chunky",
+        "Chunky",
+    ]
+    assert [record.payload["chunk_index"] for record in records] == [0, 1, 2]
+    assert [record.payload["chunk_count"] for record in records] == [3, 3, 3]
+
+
+def test_persist_extracted_payload_upserts_payload_metadata_without_semantic_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_upsert_records(collection_name: str, records: list[object]) -> None:
+        captured["collection_name"] = collection_name
+        captured["payload"] = records[0].payload
+
+    monkeypatch.setattr(document_persistence, "_upsert_records", fake_upsert_records)
+
+    asyncio.run(
+        persist_extracted_payload(
+            "insurances",
+            {
+                "id": "insurance-ai-4",
+                "insurance_type": "vision",
+                "status": "requires_human_review",
+                "raw_text": "Vision policy",
+            },
+            metadata_kind="insurance",
+        )
+    )
+
+    assert captured["collection_name"] == "insurances"
+    assert captured["payload"]["insurance_type"] == "vision"
+    assert captured["payload"]["status"] == "requires_human_review"
+    assert captured["payload"]["insurance_number"] is None
+    assert captured["payload"]["provider_name"] is None


### PR DESCRIPTION
### Motivation
- Ensure vector DB persistence only stores metadata produced by the AI/LLM extraction step and stop hardcoding semantic defaults inside the save layer.
- Move validation and chunking responsibilities into the vector DB save workflow so the persistence layer accepts an already-extracted payload and persists it as-is.

### Description
- Added validated metadata models (`CandidateVectorMetadata`, `InsuranceVectorMetadata`, `GenericVectorMetadata`) and a `VectorDbRecord` model using `pydantic` to enforce allowed metadata shapes and value types before upsert.
- Introduced a vector DB pipeline: `build_vector_db_metadata` → `build_vector_db_records` (creates chunked embedding records) → `_upsert_records`, and a public helper `persist_extracted_payload` that accepts an extracted payload and persists validated records without assigning semantic defaults.
- Reworked `persist_document_if_supported` and `_upsert_payload` to route extracted payloads into the new pipeline while keeping the public collection API unchanged (`QDRANT_CANDIDATES_COLLECTION`, `QDRANT_INSURANCES_COLLECTION`).
- Added helpers for chunking (`_split_embedding_text`, `_chunk_record_id`, `_embedding_text_from_payload`), metadata validation (`_validate_metadata_values`), and a placeholder embedding function returning `[0.0]` for testability; updated `README.md` and `pyproject.toml` to document the behavior and add `pydantic` dependency.

### Testing
- Ran static/compile check with `python -m compileall src` which passed.
- Ran unit tests with `PYTHONPATH=src pytest -q` which passed: 56 tests, 1 existing Starlette deprecation warning.
- Added unit tests verifying that `build_vector_db_metadata` preserves values from the supplied extracted payload, allows missing optional fields, `build_vector_db_records` chunking preserves payload metadata, and `persist_extracted_payload` upserts records without injecting semantic defaults (all assertions passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fd688de20832894ba2b03581ad32d)