### PR TITLE
feat: map insurance PDFs to insurance schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ curl -X POST "http://127.0.0.1:8000/api/documents/pdf" \
 
 Successful responses contain only the Ollama answer as `{"response":"result based on the uploaded PDF"}`.
 
-When the uploaded text is classified as a CV/resume or insurance policy, the service also upserts vector DB records in the configured `candidates` or `insurances` collection. The vector DB save workflow receives an already-extracted payload, validates it against metadata schemas, optionally splits long `raw_text` into chunk records, and persists the resulting metadata without assigning semantic defaults such as candidate names, statuses, insurance types, or skills inside the save layer. Missing optional metadata fields remain `None` or empty lists unless the extracted payload itself contains a value.
+When the uploaded text is classified as a CV/resume or insurance policy, the service also upserts vector DB records in the configured `candidates` or `insurances` collection. Insurance PDFs are mapped to a single `insurances` record using the fields `id`, `candidate_id`, `policy_number`, `insurance_provider`, `insurance_type`, `policy_holder`, `coverage_details`, `start_date`, `end_date`, `premium_amount`, `currency`, `beneficiary`, `created_at`, and `updated_at`. Multi-page insurance PDFs are persisted as one insurance record rather than one record per page or text chunk. Candidate payloads can still split long `raw_text` into chunk records for vector search. Missing optional metadata fields remain `None` or empty lists unless the extracted payload itself contains a value.
 
 ### POST `/api/prompts/execute`
 

--- a/src/services/document_persistence.py
+++ b/src/services/document_persistence.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import re
+import uuid
 from datetime import datetime, timezone
 from typing import Any
 
@@ -52,12 +53,17 @@ class InsuranceVectorMetadata(BaseModel):
 
     id: str = Field(..., min_length=1)
     document_hash: str | None = None
-    insurance_number: str | None = None
+    candidate_id: str | None = None
+    policy_number: str | None = None
+    insurance_provider: str | None = None
     insurance_type: str | None = None
-    provider_name: str | None = None
-    status: str | None = None
+    policy_holder: dict[str, Any] | None = None
     coverage_details: dict[str, Any] | None = None
-    documents: list[dict[str, Any]] = Field(default_factory=list)
+    start_date: str | None = None
+    end_date: str | None = None
+    premium_amount: float | None = None
+    currency: str = "EUR"
+    beneficiary: dict[str, Any] | None = None
     raw_text: str | None = None
     created_at: str | None = None
     updated_at: str | None = None
@@ -141,20 +147,50 @@ def build_insurance_payload(document_text: str) -> dict[str, Any]:
         document_text,
         capture_group=1,
     )
-    provider_name = _extract_insurance_provider_name(document_text)
+    premium_amount, premium_currency = _extract_money_components_for_label(
+        document_text, ("premium", "amount due")
+    )
+    coverage_limit, _coverage_currency = _extract_money_components_for_label(
+        document_text, ("coverage limit", "limit", "sum insured")
+    )
+    timestamp = _utc_timestamp()
 
     return {
-        "id": f"insurance-{document_hash}",
+        "id": str(uuid.uuid5(uuid.NAMESPACE_URL, f"insurance:{document_hash}")),
         "document_hash": document_hash,
-        "insurance_number": policy_number or f"unknown-{document_hash[:12]}",
+        "candidate_id": _extract_candidate_id(document_text),
+        "policy_number": policy_number or f"unknown-{document_hash[:12]}",
+        "insurance_provider": _extract_insurance_provider_name(document_text),
         "insurance_type": _detect_insurance_type(document_text),
-        "provider_name": provider_name,
-        "status": _detect_insurance_status(document_text),
-        "coverage_details": _extract_insurance_coverage_details(document_text),
-        "documents": _extract_insurance_document_references(document_text),
+        "policy_holder": _extract_person_name_json(
+            _extract_first(
+                r"(?:policyholder|policy holder|insured|member|name)\s*[:\-]\s*([^\n]+)",
+                document_text,
+                capture_group=1,
+            )
+        ),
+        "coverage_details": _extract_insurance_coverage_details(
+            document_text, coverage_limit=coverage_limit
+        ),
+        "start_date": _normalize_date(
+            _extract_labeled_date(
+                document_text, ("effective date", "start date", "valid from")
+            )
+        ),
+        "end_date": _normalize_date(
+            _extract_labeled_date(
+                document_text,
+                ("expiration date", "expiry date", "end date", "valid until"),
+            )
+        ),
+        "premium_amount": premium_amount if premium_amount is not None else 0.0,
+        "currency": (
+            premium_currency or _extract_labeled_currency(document_text) or "EUR"
+        ),
+        "beneficiary": _extract_beneficiary(document_text),
         "raw_text": document_text,
-        "created_at": _utc_timestamp(),
-        "updated_at": _utc_timestamp(),
+        "created_at": timestamp,
+        "updated_at": timestamp,
     }
 
 
@@ -178,7 +214,7 @@ async def persist_extracted_payload(
     """Persist already-extracted LLM payload metadata to the vector DB.
 
     The vector DB workflow validates and persists the metadata it receives. It does
-    not infer or hardcode semantic metadata such as status, skills, candidate names,
+    not infer or hardcode semantic metadata such as skills, candidate names,
     document types, or insurance types.
     """
     records = build_vector_db_records(extracted_payload, metadata_kind=metadata_kind)
@@ -193,7 +229,12 @@ def build_vector_db_records(
     metadata = build_vector_db_metadata(
         extracted_payload, metadata_kind=metadata_kind
     )
-    chunks = _split_embedding_text(_embedding_text_from_payload(metadata))
+    embedding_text = _embedding_text_from_payload(metadata)
+    chunks = (
+        [embedding_text]
+        if metadata_kind == "insurance"
+        else _split_embedding_text(embedding_text)
+    )
     return [
         VectorDbRecord(
             id=_qdrant_point_id(
@@ -223,7 +264,16 @@ def build_vector_db_metadata(
 
 
 async def _upsert_payload(collection_name: str, payload: dict[str, Any]) -> None:
-    await persist_extracted_payload(collection_name, payload)
+    metadata_kind = _metadata_kind_for_collection(collection_name)
+    await persist_extracted_payload(collection_name, payload, metadata_kind=metadata_kind)
+
+
+def _metadata_kind_for_collection(collection_name: str) -> str | None:
+    if collection_name == QDRANT_CANDIDATES_COLLECTION:
+        return "candidate"
+    if collection_name == QDRANT_INSURANCES_COLLECTION:
+        return "insurance"
+    return None
 
 
 async def _upsert_records(
@@ -435,28 +485,16 @@ def _extract_insurance_provider_name(text: str) -> str:
     return "unknown"
 
 
-def _extract_insurance_coverage_details(text: str) -> dict[str, Any]:
+def _extract_insurance_coverage_details(
+    text: str, *, coverage_limit: float | None = None
+) -> dict[str, Any]:
     details = _without_empty_values(
         {
-            "policyholder": _extract_first(
-                r"(?:policyholder|insured|member|name)\s*[:\-]\s*([^\n]+)",
-                text,
-                capture_group=1,
-            ),
-            "effective_date": _extract_labeled_date(
-                text, ("effective date", "start date", "valid from")
-            ),
-            "expiration_date": _extract_labeled_date(
-                text, ("expiration date", "expiry date", "end date", "valid until")
-            ),
-            "premium": _extract_money_for_label(text, ("premium", "amount due")),
+            "coverage_limit": coverage_limit,
+            "medical": _detect_coverage_flag(text, "medical"),
+            "dental": _detect_coverage_flag(text, "dental"),
+            "accident": _detect_coverage_flag(text, "accident"),
             "deductible": _extract_money_for_label(text, ("deductible", "excess")),
-            "coverage_limit": _extract_money_for_label(
-                text, ("coverage limit", "limit", "sum insured")
-            ),
-            "beneficiary": _extract_first(
-                r"beneficiary\s*[:\-]\s*([^\n]+)", text, capture_group=1
-            ),
         }
     )
     coverages = _extract_coverage_lines(text)
@@ -466,6 +504,75 @@ def _extract_insurance_coverage_details(text: str) -> dict[str, Any]:
     if exclusions:
         details["exclusions"] = exclusions
     return details
+
+
+def _extract_candidate_id(text: str) -> str | None:
+    return _extract_first(
+        r"candidate\s*(?:id|uuid)\s*[:\-]?\s*"
+        r"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-"
+        r"[0-9a-f]{4}-[0-9a-f]{12})",
+        text,
+        capture_group=1,
+    )
+
+
+def _extract_person_name_json(full_name: str | None) -> dict[str, str] | None:
+    if not full_name:
+        return None
+    cleaned = _strip_inline_metadata(full_name)
+    first_name, last_name = _split_name(cleaned)
+    if first_name == "unknown" and last_name == "unknown":
+        return None
+    return _without_empty_values({"first_name": first_name, "last_name": last_name})
+
+
+def _extract_beneficiary(text: str) -> dict[str, str] | None:
+    beneficiary_text = _extract_first(
+        r"beneficiary\s*[:\-]\s*([^\n]+)", text, capture_group=1
+    )
+    if not beneficiary_text:
+        return None
+    relationship = _extract_first(
+        r"relationship\s*[:\-]\s*([^,;\n]+)", beneficiary_text, capture_group=1
+    )
+    name = re.sub(
+        r"\brelationship\s*[:\-]\s*[^,;\n]+", "", beneficiary_text, flags=re.IGNORECASE
+    ).strip(" ,;|-\t")
+    if not relationship:
+        relation_match = re.search(
+            r"(.+?)\s*[,;(]\s*(spouse|partner|child|parent|sibling|friend|other)\)?$",
+            name,
+            flags=re.IGNORECASE,
+        )
+        if relation_match:
+            name = relation_match.group(1).strip()
+            relationship = relation_match.group(2).strip().title()
+    return _without_empty_values(
+        {"name": _strip_inline_metadata(name), "relationship": relationship}
+    )
+
+
+def _strip_inline_metadata(value: str) -> str:
+    return re.split(
+        r"\s+(?:relationship|date|dob|birth|policy|coverage|premium)\s*[:\-]",
+        value.strip(),
+        maxsplit=1,
+        flags=re.IGNORECASE,
+    )[0].strip(" ,;|-\t")
+
+
+def _detect_coverage_flag(text: str, label: str) -> bool | None:
+    explicit = _extract_first(
+        rf"\b{re.escape(label)}\b\s*[:\-]?\s*"
+        r"(true|false|yes|no|covered|included|excluded|not covered)",
+        text,
+        capture_group=1,
+    )
+    if explicit:
+        return explicit.lower() in {"true", "yes", "covered", "included"}
+    if re.search(rf"\b{re.escape(label)}\b", text, flags=re.IGNORECASE):
+        return True
+    return None
 
 
 def _extract_insurance_document_references(text: str) -> list[dict[str, str]]:
@@ -756,10 +863,103 @@ def _extract_labeled_date(text: str, labels: tuple[str, ...]) -> str | None:
 def _extract_money_for_label(text: str, labels: tuple[str, ...]) -> str | None:
     label_pattern = "|".join(re.escape(label) for label in labels)
     return _extract_first(
-        rf"(?:{label_pattern})\s*[:\-]?\s*((?:CHF|USD|EUR|GBP|\$|€|£)\s?[0-9][0-9'.,]*)",
+        rf"(?:{label_pattern})\s*[:\-]?\s*"
+        r"((?:(?:CHF|USD|EUR|GBP|\$|€|£)\s*)?[0-9][0-9'.,]*)",
         text,
         capture_group=1,
     )
+
+
+def _extract_money_components_for_label(
+    text: str, labels: tuple[str, ...]
+) -> tuple[float | None, str | None]:
+    money = _extract_money_for_label(text, labels)
+    if not money:
+        return None, None
+    currency = _currency_from_money(money)
+    amount_text = re.sub(
+        r"(?:CHF|USD|EUR|GBP|\$|€|£)", "", money, flags=re.IGNORECASE
+    )
+    normalized_amount = amount_text.replace("'", "").replace(" ", "")
+    if "," in normalized_amount and "." in normalized_amount:
+        normalized_amount = normalized_amount.replace(",", "")
+    elif "," in normalized_amount:
+        normalized_amount = normalized_amount.replace(",", ".")
+    try:
+        return round(float(normalized_amount), 2), currency
+    except ValueError:
+        return None, currency
+
+
+def _currency_from_money(money: str) -> str | None:
+    currency_match = re.search(r"CHF|USD|EUR|GBP|\$|€|£", money, flags=re.IGNORECASE)
+    if not currency_match:
+        return None
+    symbol_or_code = currency_match.group(0).upper()
+    return {"$": "USD", "€": "EUR", "£": "GBP"}.get(symbol_or_code, symbol_or_code)
+
+
+def _extract_labeled_currency(text: str) -> str | None:
+    explicit = _extract_first(
+        r"currency\s*[:\-]\s*([A-Z]{3})", text, capture_group=1
+    )
+    if explicit:
+        return explicit.upper()
+    money_match = re.search(
+        r"(?:CHF|USD|EUR|GBP|\$|€|£)", text, flags=re.IGNORECASE
+    )
+    return _currency_from_money(money_match.group(0)) if money_match else None
+
+
+def _normalize_date(value: str | None) -> str | None:
+    if not value:
+        return None
+    stripped = value.strip()
+    iso_match = re.fullmatch(r"(\d{4})-(\d{2})-(\d{2})", stripped)
+    if iso_match:
+        return stripped
+    numeric_match = re.fullmatch(
+        r"(\d{1,2})[./-](\d{1,2})[./-](\d{2,4})", stripped
+    )
+    if numeric_match:
+        day = int(numeric_match.group(1))
+        month = int(numeric_match.group(2))
+        year = int(numeric_match.group(3))
+        if year < 100:
+            year += 2000
+        if day > 12 or month <= 12:
+            return f"{year:04d}-{month:02d}-{day:02d}"
+    month_match = re.fullmatch(
+        r"([A-Za-z]+)\s+(\d{1,2}),?\s+(\d{4})", stripped
+    )
+    if month_match:
+        months = {
+            name.lower(): index
+            for index, name in enumerate(
+                (
+                    "January",
+                    "February",
+                    "March",
+                    "April",
+                    "May",
+                    "June",
+                    "July",
+                    "August",
+                    "September",
+                    "October",
+                    "November",
+                    "December",
+                ),
+                start=1,
+            )
+        }
+        month_text = month_match.group(1).lower()
+        month = months.get(month_text) or months.get(f"{month_text[:3]}uary")
+        short_months = {name[:3].lower(): index for name, index in months.items()}
+        month = month or short_months.get(month_text[:3])
+        if month:
+            return f"{int(month_match.group(3)):04d}-{month:02d}-{int(month_match.group(2)):02d}"
+    return stripped
 
 
 def _extract_coverage_lines(text: str) -> list[str]:

--- a/tests/unit/test_document_persistence.py
+++ b/tests/unit/test_document_persistence.py
@@ -154,10 +154,11 @@ def test_build_insurance_payload_extracts_policy_fields() -> None:
         "Policy Number: POL-001\nProvider: Acme Insurance\nStatus: active\nHealth coverage"
     )
 
-    assert payload["insurance_number"] == "POL-001"
-    assert payload["provider_name"] == "Acme Insurance"
-    assert payload["status"] == "active"
+    assert payload["policy_number"] == "POL-001"
+    assert payload["insurance_provider"] == "Acme Insurance"
     assert payload["insurance_type"] == "health"
+    assert payload["currency"] == "EUR"
+    assert payload["premium_amount"] == 0.0
 
 
 def test_build_insurance_payload_maps_policy_fields_to_coverage_details() -> None:
@@ -175,18 +176,18 @@ def test_build_insurance_payload_maps_policy_fields_to_coverage_details() -> Non
         "Endorsement No. END-42"
     )
 
-    assert payload["provider_name"] == "Acme Insurance"
+    assert payload["insurance_provider"] == "Acme Insurance"
+    assert payload["policy_holder"] == {"first_name": "Jane", "last_name": "Doe"}
+    assert payload["start_date"] == "2026-01-01"
+    assert payload["end_date"] == "2026-12-31"
+    assert payload["premium_amount"] == 1200.0
+    assert payload["currency"] == "CHF"
     assert payload["coverage_details"] == {
-        "policyholder": "Jane Doe",
-        "effective_date": "01/01/2026",
-        "expiration_date": "31/12/2026",
-        "premium": "CHF 1'200.00",
+        "coverage_limit": 100000.0,
         "deductible": "CHF 500",
-        "coverage_limit": "CHF 100'000",
         "coverages": ["Coverage Limit: CHF 100'000", "Coverage: emergency health care"],
         "exclusions": ["Exclusion: pre-existing conditions"],
     }
-    assert payload["documents"] == [{"type": "endorsement", "reference": "END-42"}]
 
 
 def test_build_candidate_payload_uses_stable_document_identity() -> None:
@@ -208,7 +209,7 @@ def test_build_insurance_payload_uses_stable_unknown_policy_number() -> None:
     )
 
     assert first_payload["document_hash"] == second_payload["document_hash"]
-    assert first_payload["insurance_number"] == second_payload["insurance_number"]
+    assert first_payload["policy_number"] == second_payload["policy_number"]
 
 
 def test_persist_document_if_supported_upserts_cv_payload(
@@ -272,23 +273,23 @@ def test_persist_document_if_supported_saves_new_insurance(
 def test_build_vector_metadata_uses_extracted_insurance_payload_values() -> None:
     payload = {
         "id": "insurance-ai-1",
-        "insurance_number": "AI-POL-999",
+        "policy_number": "AI-POL-999",
         "insurance_type": "dental",
-        "provider_name": "Payload Mutual",
-        "status": "pending_review",
+        "insurance_provider": "Payload Mutual",
+        "policy_holder": {"first_name": "Amina", "last_name": "Policy"},
         "coverage_details": {"coverages": ["orthodontics"]},
-        "documents": [{"type": "policy", "reference": "DOC-7"}],
+        "premium_amount": 25.5,
         "raw_text": "Extracted policy text",
     }
 
     metadata = build_vector_db_metadata(payload, metadata_kind="insurance")
 
-    assert metadata["insurance_number"] == "AI-POL-999"
+    assert metadata["policy_number"] == "AI-POL-999"
     assert metadata["insurance_type"] == "dental"
-    assert metadata["provider_name"] == "Payload Mutual"
-    assert metadata["status"] == "pending_review"
+    assert metadata["insurance_provider"] == "Payload Mutual"
+    assert metadata["policy_holder"] == {"first_name": "Amina", "last_name": "Policy"}
     assert metadata["coverage_details"] == {"coverages": ["orthodontics"]}
-    assert metadata["documents"] == [{"type": "policy", "reference": "DOC-7"}]
+    assert metadata["premium_amount"] == 25.5
 
 
 def test_build_vector_metadata_allows_missing_optional_insurance_fields() -> None:
@@ -297,12 +298,13 @@ def test_build_vector_metadata_allows_missing_optional_insurance_fields() -> Non
         metadata_kind="insurance",
     )
 
-    assert metadata["insurance_number"] is None
+    assert metadata["policy_number"] is None
     assert metadata["insurance_type"] is None
-    assert metadata["provider_name"] is None
-    assert metadata["status"] is None
+    assert metadata["insurance_provider"] is None
+    assert metadata["policy_holder"] is None
     assert metadata["coverage_details"] is None
-    assert metadata["documents"] == []
+    assert metadata["premium_amount"] is None
+    assert metadata["currency"] == "EUR"
 
 
 def test_build_vector_metadata_uses_extracted_candidate_payload_values() -> None:
@@ -387,7 +389,7 @@ def test_persist_extracted_payload_upserts_payload_metadata_without_semantic_def
             {
                 "id": "insurance-ai-4",
                 "insurance_type": "vision",
-                "status": "requires_human_review",
+                "policy_number": "VIS-1",
                 "raw_text": "Vision policy",
             },
             metadata_kind="insurance",
@@ -396,6 +398,57 @@ def test_persist_extracted_payload_upserts_payload_metadata_without_semantic_def
 
     assert captured["collection_name"] == "insurances"
     assert captured["payload"]["insurance_type"] == "vision"
-    assert captured["payload"]["status"] == "requires_human_review"
-    assert captured["payload"]["insurance_number"] is None
-    assert captured["payload"]["provider_name"] is None
+    assert captured["payload"]["policy_number"] == "VIS-1"
+    assert captured["payload"]["insurance_provider"] is None
+    assert captured["payload"]["currency"] == "EUR"
+
+
+def test_build_insurance_payload_maps_requested_insurance_schema_fields() -> None:
+    payload = build_insurance_payload(
+        "SafeLife Insurance\n"
+        "Candidate ID: 123e4567-e89b-12d3-a456-426614174000\n"
+        "Policy Number: LIFE-42\n"
+        "Insurance Type: Life\n"
+        "Policy Holder: John Doe\n"
+        "Coverage Limit: 500000\n"
+        "Medical: true\n"
+        "Dental: false\n"
+        "Accident: yes\n"
+        "Start Date: 2026-02-01\n"
+        "End Date: 2027-02-01\n"
+        "Premium: 49.90\n"
+        "Beneficiary: Jane Doe, Spouse"
+    )
+
+    assert payload["candidate_id"] == "123e4567-e89b-12d3-a456-426614174000"
+    assert payload["policy_number"] == "LIFE-42"
+    assert payload["insurance_provider"] == "SafeLife Insurance"
+    assert payload["insurance_type"] == "life"
+    assert payload["policy_holder"] == {"first_name": "John", "last_name": "Doe"}
+    assert payload["coverage_details"]["coverage_limit"] == 500000.0
+    assert payload["coverage_details"]["medical"] is True
+    assert payload["coverage_details"]["dental"] is False
+    assert payload["coverage_details"]["accident"] is True
+    assert payload["start_date"] == "2026-02-01"
+    assert payload["end_date"] == "2027-02-01"
+    assert payload["premium_amount"] == 49.9
+    assert payload["currency"] == "EUR"
+    assert payload["beneficiary"] == {"name": "Jane Doe", "relationship": "Spouse"}
+
+
+def test_build_vector_records_keeps_multipage_insurance_pdf_in_one_record(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(document_persistence, "VECTOR_DB_CHUNK_SIZE", 5)
+
+    records = build_vector_db_records(
+        build_insurance_payload(
+            "Policy Number: MULTI-1\nProvider: Acme Insurance\n"
+            "Premium: EUR 10.00\nCoverage Limit: EUR 1000"
+        ),
+        metadata_kind="insurance",
+    )
+
+    assert len(records) == 1
+    assert records[0].payload["policy_number"] == "MULTI-1"
+    assert "chunk_index" not in records[0].payload


### PR DESCRIPTION
### Motivation
- Persist insurance PDFs into a structured `insurances` record that matches the requested DB schema rather than using generic or per-page chunk records. 
- Ensure multi-page insurance PDFs are saved as a single policy record for reliable lookup and auditing. 
- Improve extraction of monetary, date, policy-holder and beneficiary values so stored metadata is more useful for downstream automation. 

### Description
- Updated `src/services/document_persistence.py` to produce an insurance-aligned payload with fields `id`, `candidate_id`, `policy_number`, `insurance_provider`, `insurance_type`, `policy_holder`, `coverage_details`, `start_date`, `end_date`, `premium_amount`, `currency`, `beneficiary`, `created_at`, and `updated_at` and to use a deterministic UUID for `id`. 
- Added helper parsers for money (`_extract_money_components_for_label`, `_currency_from_money`), date normalization (`_normalize_date`), policy-holder/beneficiary extraction (`_extract_person_name_json`, `_extract_beneficiary`), coverage flag detection (`_detect_coverage_flag`), and candidate id extraction (`_extract_candidate_id`). 
- Preserved candidate payload behavior while forcing insurance metadata to be treated as a single embedding record by making `build_vector_db_records` keep the whole `raw_text` as one chunk when `metadata_kind == "insurance"`. 
- Introduced `_metadata_kind_for_collection` and wired `_upsert_payload` to pass the correct metadata kind; updated README and unit tests to reflect the new insurance schema and single-record multi-page behavior. 

### Testing
- Ran static compile: `python -m compileall src` which succeeded. 
- Ran unit test suite: `pytest -q` which passed (58 passed; one existing Starlette deprecation warning reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ff4acbe6483289f0cd7cb68cafcab)