### PR TITLE
feat: database-first PDF workflow for CVs and Insurances

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Document-processing blueprints include a `cv-reader-agent` for reading CVs, resu
 - `candidate-profile-extraction`
 - `experience-skills-normalization`
 
-The CV reader agent extracts evidence-backed candidate facts, timelines, education, certifications, projects, skills, and review warnings from supplied document text while protecting PII and avoiding unsupported hiring decisions. Persisted candidate payloads keep `education` as a list of obtained degrees, `certification` as a list of earned certifications, and `languages` as a list of candidate languages.
+The CV reader agent extracts evidence-backed candidate facts, timelines, education, certifications, projects, skills, and review warnings from supplied document text while protecting PII and avoiding unsupported hiring decisions. Persisted candidate payloads support the `language` field and the `certifications` field alongside JSON payloads for `competences`, `previous_works`, and `education`.
 
 ## Rotative logs for MCP tools
 
@@ -131,11 +131,11 @@ Example:
 OLLAMA_TIMEOUT_SECONDS=600 python src/server.py
 ```
 
-If you still get timeouts, try reducing prompt size by passing `max_chars` in `process_pdf`.
+If you still get timeouts, try reducing the text available for classification and first-time extraction by passing `max_chars` in `process_pdf`.
 
 ## Frontend prompt router API
 
-The HTTP API exposes prompt execution plus PDF upload endpoints. For prompts, the frontend sends only the user message in the JSON body as `{"message":"prompt"}`; the service routes that message to the correct document, health, or general chat tool, uses the inferred tool and related skills as Ollama context when applicable, and returns only the model answer as `{"response":"result of the prompt"}`. For PDFs, the frontend sends `multipart/form-data` with a PDF file and question, and receives an Ollama answer based on the uploaded document content.
+The HTTP API exposes prompt execution plus PDF upload endpoints. For prompts, the frontend sends only the user message in the JSON body as `{"message":"prompt"}`; the service routes that message to the correct document, health, or general chat tool, uses the inferred tool and related skills as Ollama context when applicable, and returns only the model answer as `{"response":"result of the prompt"}`. For PDFs, the frontend sends `multipart/form-data` with a PDF file and question; the service detects CV versus insurance, checks the database first, extracts only missing records, retrieves the database record, and answers using that record as the single source of truth.
 
 ### Run the HTTP API locally
 
@@ -166,13 +166,13 @@ The Swagger page is backed by `http://127.0.0.1:8000/openapi.json`.
 
 ### POST `/api/documents/pdf`
 
-Use this endpoint when the frontend needs to upload a PDF with `multipart/form-data` and ask a question about the document content. The API extracts text from the PDF first, then sends that extracted text to Ollama. Ollama does **not** read the raw PDF binary directly. Scanned or image-only PDFs need OCR before this endpoint can answer questions from their content.
+Use this endpoint when the frontend needs to upload a CV or insurance PDF with `multipart/form-data` and ask a question about the stored document data. The API extracts text from the PDF server-side for classification, document hashing, and first-time structured extraction only. It does not answer directly from the PDF text. Scanned or image-only PDFs need OCR before this endpoint can classify or extract their content.
 
 The form fields are:
 
 - `file`: required PDF upload.
-- `question`: required question to answer from the PDF content.
-- `max_chars`: optional maximum extracted characters to include in the model prompt; defaults to `30000`.
+- `question`: required question to answer from the stored database record.
+- `max_chars`: optional maximum extracted characters available for classification and first-time extraction; defaults to `30000`.
 
 ```bash
 curl -X POST "http://127.0.0.1:8000/api/documents/pdf" \
@@ -181,9 +181,11 @@ curl -X POST "http://127.0.0.1:8000/api/documents/pdf" \
   -F "max_chars=30000"
 ```
 
-Successful responses contain only the Ollama answer as `{"response":"result based on the uploaded PDF"}`.
+Successful responses contain only the answer as `{"response":"result based on the database record"}`.
 
-When uploaded text is classified as a CV/resume or insurance policy, the service also upserts vector DB records in the configured `candidates` or `insurances` collection. Classification and metadata extraction are performed exclusively by the configured Ollama model: PDF text is classified with `infer_pdf_domain_with_ollama()`, extracted with `build_payload_with_ollama()`, validated through the Pydantic vector metadata schemas, and then persisted to Qdrant. The extraction prompt includes the complete JSON schema for the target payload and asks Ollama for strict JSON-only output; when supported by the Ollama API, the same schema is also sent as structured output format. The vector DB layer is storage-only and does not infer, guess, regex-match, keyword-match, or hardcode CV/insurance semantic fields. The service fills operational fields such as `id`, `document_hash`, `raw_text`, `created_at`, and `updated_at`, while the model maps explicitly supported document values into fields such as `first_name`, `education`, `policy_number`, `start_date`, and `coverage_details`. Insurance PDFs are mapped to a single `insurances` record rather than one record per page or text chunk. Candidate payloads can still split long `raw_text` into chunk records for vector search. Missing optional metadata fields remain `None` or empty lists unless the extracted payload itself contains a value.
+Expected PDF workflow: upload PDF → detect document type → check the matching database collection → if the record exists, retrieve it and answer from database fields only → if the record is missing, extract structured data once with Ollama, save it, retrieve the saved record, and answer from database fields only. CVs use the `candidates` collection; insurance documents use the `insurances` collection. The removed legacy workflow no longer asks Ollama to answer from PDF text before reprocessing the same PDF for extraction.
+
+Candidate records support `id`, `first_name`, `last_name`, `email`, `phone`, `seniority`, `city`, `country`, `address`, `competences`, `previous_works`, `education`, `current_job_title`, `current_company`, `availability_date`, `notes`, `language`, `certifications`, `created_at`, and `updated_at`. Insurance records support `id`, `candidate_id`, `policy_number`, `insurance_provider`, `insurance_type`, `policy_holder`, `coverage_details`, `start_date`, `end_date`, `premium_amount`, `currency`, `beneficiary`, `created_at`, and `updated_at`. The service also stores operational `document_hash` values to detect duplicates and uses `raw_text` only for indexing/storage, not for answer prompts.
 
 ### POST `/api/prompts/execute`
 

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -75,14 +75,14 @@ else:
             "info": {
                 "title": SERVICE_NAME,
                 "version": "0.1.0",
-                "description": "HTTP API for frontend prompt routing with Ollama-only answers.",
+                "description": "HTTP API for frontend prompt routing and database-first PDF answers.",
             },
             "paths": {
                 "/api/documents/pdf": {
                     "post": {
                         "tags": ["documents"],
-                        "summary": "Upload a PDF with multipart form data and answer a question using extracted text.",
-                        "description": "The API extracts PDF text server-side, then sends that extracted text to Ollama. Ollama does not receive or parse raw PDF bytes.",
+                        "summary": "Upload a PDF and answer through the database-first CV/insurance workflow.",
+                        "description": "The API extracts PDF text server-side, detects CV versus insurance, checks the candidates or insurances database collection, extracts only when no record exists, retrieves the saved record, and answers from that database record. The database is the single source of truth for answers.",
                         "requestBody": {
                             "required": True,
                             "content": {
@@ -99,13 +99,13 @@ else:
                                             "question": {
                                                 "type": "string",
                                                 "minLength": 1,
-                                                "description": "Question to answer using the uploaded PDF content.",
+                                                "description": "Question to answer using the database record for the uploaded PDF.",
                                             },
                                             "max_chars": {
                                                 "type": "integer",
                                                 "default": 30000,
                                                 "minimum": 1,
-                                                "description": "Maximum extracted PDF characters to include in the model prompt.",
+                                                "description": "Maximum extracted PDF characters available for classification and new-record extraction.",
                                             },
                                         },
                                     }

--- a/src/server.py
+++ b/src/server.py
@@ -14,11 +14,8 @@ from tools.blueprints import (
     list_platform_blueprints_tool,
     resolve_document_processing_flow_tool,
 )
-from tools.document import (
-    build_document_prompt,
-    extract_pdf_text,
-    truncate_document_text,
-)
+from services.document_persistence import answer_document_prompt_from_database
+from tools.document import extract_pdf_text, truncate_document_text
 
 mcp = FastMCP(name=SERVICE_NAME, mask_error_details=True)
 logger = get_logger()
@@ -31,14 +28,14 @@ async def send_prompt(prompt: str) -> str:
 
 
 @mcp.tool(
-    description="Extract text from a PDF file and answer a question using local Ollama."
+    description="Process a CV or insurance PDF through the database-first workflow."
 )
 async def process_pdf(file_path: str, question: str, max_chars: int = 30000) -> str:
     logger.info("Tool process_pdf called for file_path=%s", file_path)
     document_text = extract_pdf_text(file_path)
     truncated_text = truncate_document_text(document_text, max_chars=max_chars)
-    prompt = build_document_prompt(truncated_text, question)
-    return await chat_with_ollama(prompt)
+    workflow_result = await answer_document_prompt_from_database(truncated_text, question)
+    return workflow_result.response
 
 
 @mcp.tool(

--- a/src/services/document_persistence.py
+++ b/src/services/document_persistence.py
@@ -4,9 +4,10 @@ import hashlib
 import json
 import uuid
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Literal
 
 import httpx
+from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
 from clients.ollama import chat_with_ollama
@@ -19,6 +20,8 @@ from config import (
 
 
 VECTOR_DB_CHUNK_SIZE = 4000
+DocumentDomain = Literal["cv", "insurance", "other"]
+MetadataKind = Literal["candidate", "insurance"]
 
 
 class VectorDbMetadataError(ValueError):
@@ -26,34 +29,40 @@ class VectorDbMetadataError(ValueError):
 
 
 class CandidateVectorMetadata(BaseModel):
-    """Validated candidate metadata produced by the extraction layer."""
+    """Candidate table payload used as the source of truth for CV answers."""
 
     model_config = ConfigDict(extra="allow")
 
     id: str = Field(..., min_length=1)
-    document_hash: str | None = None
     first_name: str | None = None
     last_name: str | None = None
     email: str | None = None
     phone: str | None = None
     seniority: str | None = None
-    competences: dict[str, Any] | None = None
+    city: str | None = None
+    country: str | None = None
+    address: str | None = None
+    competences: dict[str, Any] | list[Any] | None = None
     previous_works: list[dict[str, Any]] = Field(default_factory=list)
-    education: list[str] = Field(default_factory=list)
-    certification: list[str] = Field(default_factory=list)
-    languages: list[str] = Field(default_factory=list)
+    education: list[dict[str, Any]] | list[str] = Field(default_factory=list)
+    current_job_title: str | None = None
+    current_company: str | None = None
+    availability_date: str | None = None
+    notes: str | None = None
+    language: str | list[str] | None = None
+    certifications: list[str] | list[dict[str, Any]] = Field(default_factory=list)
+    document_hash: str | None = None
     raw_text: str | None = None
     created_at: str | None = None
     updated_at: str | None = None
 
 
 class InsuranceVectorMetadata(BaseModel):
-    """Validated insurance metadata produced by the extraction layer."""
+    """Insurance table payload used as the source of truth for insurance answers."""
 
     model_config = ConfigDict(extra="allow")
 
     id: str = Field(..., min_length=1)
-    document_hash: str | None = None
     candidate_id: str | None = None
     policy_number: str | None = None
     insurance_provider: str | None = None
@@ -63,11 +72,21 @@ class InsuranceVectorMetadata(BaseModel):
     start_date: str | None = None
     end_date: str | None = None
     premium_amount: float | None = None
-    currency: str = "EUR"
+    currency: str | None = None
     beneficiary: dict[str, Any] | None = None
+    document_hash: str | None = None
     raw_text: str | None = None
     created_at: str | None = None
     updated_at: str | None = None
+
+
+class GenericVectorMetadata(BaseModel):
+    """Validated generic metadata produced by the extraction layer."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str = Field(..., min_length=1)
+    raw_text: str | None = None
 
 
 class VectorDbRecord(BaseModel):
@@ -86,19 +105,64 @@ class VectorDbRecord(BaseModel):
         return value
 
 
-async def persist_document_if_supported(document_text: str, question: str) -> str:
+class DocumentWorkflowResult(BaseModel):
+    """Result of the database-first PDF processing workflow."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    response: str
+    document_type: DocumentDomain
+    collection_name: str | None = None
+    record_id: str | None = None
+    record_existed: bool = False
+
+
+async def answer_document_prompt_from_database(
+    document_text: str, question: str
+) -> DocumentWorkflowResult:
+    """Run the single CV/insurance pipeline with the database as source of truth.
+
+    The PDF text is used only to classify the document, compute the stable document
+    hash, and extract structured data when the corresponding database record does
+    not already exist. User-facing answers are generated exclusively from the
+    retrieved database payload, never directly from the PDF text.
+    """
     domain = await infer_pdf_domain_with_ollama(document_text, question)
-    if domain == "cv":
-        extracted_payload = await build_payload_with_ollama(document_text, "candidate")
-        await _upsert_payload(QDRANT_CANDIDATES_COLLECTION, extracted_payload)
-    elif domain == "insurance":
-        extracted_payload = await build_payload_with_ollama(document_text, "insurance")
-        await _upsert_payload(QDRANT_INSURANCES_COLLECTION, extracted_payload)
-    return domain
+    if domain == "other":
+        raise ToolError("Uploaded PDF must be either a CV or an insurance document.")
+
+    metadata_kind = _metadata_kind_for_domain(domain)
+    collection_name = _collection_for_metadata_kind(metadata_kind)
+    document_hash = _document_hash(document_text)
+
+    record = await get_document_by_hash(collection_name, document_hash)
+    record_existed = record is not None
+    if record is None:
+        extracted_payload = await extract_payload_with_ollama(document_text, metadata_kind)
+        await _upsert_payload(collection_name, extracted_payload)
+        record = await get_document_by_hash(collection_name, document_hash)
+        if record is None:
+            raise ToolError(
+                "Document was saved but could not be retrieved from the database. "
+                "Check Qdrant availability and collection indexing."
+            )
+
+    response = await build_answer_from_database_record(
+        question=question,
+        document_type=domain,
+        record=record,
+    )
+    return DocumentWorkflowResult(
+        response=response,
+        document_type=domain,
+        collection_name=collection_name,
+        record_id=str(record.get("id")) if record.get("id") is not None else None,
+        record_existed=record_existed,
+    )
 
 
-async def infer_pdf_domain_with_ollama(document_text: str, question: str) -> str:
-    """Classify document persistence domain with Ollama instead of language-specific labels."""
+async def infer_pdf_domain_with_ollama(document_text: str, question: str) -> DocumentDomain:
+    """Classify the uploaded PDF as cv, insurance, or other."""
     prompt = _build_domain_classification_prompt(document_text, question)
     raw_result = await chat_with_ollama(prompt)
     payload = _parse_json_object(raw_result)
@@ -108,13 +172,13 @@ async def infer_pdf_domain_with_ollama(document_text: str, question: str) -> str
             "Ollama document classification must return document_type as "
             "one of: cv, insurance, other."
         )
-    return domain
+    return domain  # type: ignore[return-value]
 
 
-async def build_payload_with_ollama(
-    document_text: str, metadata_kind: str
+async def extract_payload_with_ollama(
+    document_text: str, metadata_kind: MetadataKind
 ) -> dict[str, Any]:
-    """Ask Ollama to map multilingual document text to the configured DB fields."""
+    """Extract structured database payload with Ollama for a new document only."""
     schema = _metadata_schema(metadata_kind)
     prompt = _build_metadata_extraction_prompt(document_text, metadata_kind, schema)
     raw_result = await chat_with_ollama(
@@ -126,18 +190,59 @@ async def build_payload_with_ollama(
     return payload
 
 
+async def build_answer_from_database_record(
+    *, question: str, document_type: DocumentDomain, record: dict[str, Any]
+) -> str:
+    """Answer the prompt from structured database data only."""
+    answer_payload = _database_answer_payload(record)
+    prompt = _build_database_answer_prompt(question, document_type, answer_payload)
+    return await chat_with_ollama(prompt)
+
+
+async def get_document_by_hash(
+    collection_name: str, document_hash: str
+) -> dict[str, Any] | None:
+    """Retrieve the first payload matching a document hash from the collection."""
+    body = {
+        "filter": {
+            "must": [
+                {"key": "document_hash", "match": {"value": document_hash}},
+            ]
+        },
+        "limit": 1,
+        "with_payload": True,
+        "with_vector": False,
+    }
+    timeout = httpx.Timeout(QDRANT_TIMEOUT_SECONDS)
+    async with httpx.AsyncClient(base_url=QDRANT_URL, timeout=timeout) as client:
+        response = await client.post(
+            f"/collections/{collection_name}/points/scroll", json=body
+        )
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise ToolError(
+                f"Failed to query Qdrant collection '{collection_name}' for existing document."
+            ) from exc
+        data = response.json()
+
+    result = data.get("result", {})
+    points = result.get("points", result if isinstance(result, list) else [])
+    if not points:
+        return None
+    payload = points[0].get("payload", {})
+    if not isinstance(payload, dict):
+        raise ToolError("Qdrant returned a document payload with an unexpected shape.")
+    return payload
+
+
 async def persist_extracted_payload(
     collection_name: str,
     extracted_payload: dict[str, Any],
     *,
     metadata_kind: str | None = None,
 ) -> None:
-    """Persist already-extracted LLM payload metadata to the vector DB.
-
-    The vector DB workflow validates and persists the metadata it receives. It does
-    not infer or hardcode semantic metadata such as skills, candidate names,
-    document types, or insurance types.
-    """
+    """Persist already-extracted metadata to the vector DB."""
     records = build_vector_db_records(extracted_payload, metadata_kind=metadata_kind)
     await _upsert_records(collection_name, records)
 
@@ -186,14 +291,15 @@ def build_vector_db_metadata(
 
 def _build_domain_classification_prompt(document_text: str, question: str) -> str:
     return (
-        "Classify the uploaded document for vector database persistence. "
+        "Classify the uploaded document for database routing. "
         "The document can be written in any language. Use semantic meaning, not "
         "English labels. Return only one JSON object with this exact shape: "
         '{"document_type":"cv|insurance|other"}. '
         "Choose cv for CVs, resumes, curricula vitae, candidate profiles, or "
         "professional biographies. Choose insurance for policies, insurance "
         "certificates, coverage documents, claims documents, or related policy "
-        "paperwork. Choose other when neither applies.\n\n"
+        "paperwork. Choose other when neither applies. Do not answer the user "
+        "question and do not extract structured fields in this step.\n\n"
         f"User question:\n{question}\n\nDocument text:\n{document_text}"
     )
 
@@ -231,6 +337,21 @@ def _build_metadata_extraction_prompt(
     )
 
 
+def _build_database_answer_prompt(
+    question: str, document_type: DocumentDomain, record: dict[str, Any]
+) -> str:
+    database_json = json.dumps(record, indent=2, sort_keys=True, ensure_ascii=False)
+    return (
+        "Answer the user's question using only the structured database record below. "
+        "The database is the single source of truth. Do not use or refer to the "
+        "uploaded PDF text, and do not invent missing values. If the database record "
+        "does not contain enough information, say which information is unavailable.\n\n"
+        f"Document type: {document_type}\n"
+        f"User question:\n{question}\n\n"
+        f"Database record:\n{database_json}"
+    )
+
+
 def _parse_json_object(raw_result: str) -> dict[str, Any]:
     try:
         parsed = json.loads(raw_result.strip())
@@ -252,9 +373,14 @@ def _with_service_metadata(
     payload["id"] = _service_document_id(payload.get("id"), document_hash, metadata_kind)
     payload["document_hash"] = document_hash
     payload["raw_text"] = document_text
-    payload.setdefault("created_at", timestamp)
-    payload.setdefault("updated_at", timestamp)
+    payload["created_at"] = payload.get("created_at") or timestamp
+    payload["updated_at"] = timestamp
     return payload
+
+
+def _database_answer_payload(record: dict[str, Any]) -> dict[str, Any]:
+    excluded_keys = {"raw_text", "document_hash", "chunk_index", "chunk_count"}
+    return {key: value for key, value in record.items() if key not in excluded_keys}
 
 
 def _service_document_id(value: Any, document_hash: str, metadata_kind: str) -> str:
@@ -272,6 +398,20 @@ async def _upsert_payload(collection_name: str, payload: dict[str, Any]) -> None
     await persist_extracted_payload(collection_name, payload, metadata_kind=metadata_kind)
 
 
+def _metadata_kind_for_domain(domain: DocumentDomain) -> MetadataKind:
+    if domain == "cv":
+        return "candidate"
+    if domain == "insurance":
+        return "insurance"
+    raise ToolError("Uploaded PDF must be either a CV or an insurance document.")
+
+
+def _collection_for_metadata_kind(metadata_kind: MetadataKind) -> str:
+    if metadata_kind == "candidate":
+        return QDRANT_CANDIDATES_COLLECTION
+    return QDRANT_INSURANCES_COLLECTION
+
+
 def _metadata_kind_for_collection(collection_name: str) -> str | None:
     if collection_name == QDRANT_CANDIDATES_COLLECTION:
         return "candidate"
@@ -286,7 +426,15 @@ async def _upsert_records(
     body = {"points": [record.model_dump(mode="json") for record in records]}
     timeout = httpx.Timeout(QDRANT_TIMEOUT_SECONDS)
     async with httpx.AsyncClient(base_url=QDRANT_URL, timeout=timeout) as client:
-        await client.put(f"/collections/{collection_name}/points", json=body)
+        response = await client.put(
+            f"/collections/{collection_name}/points",
+            params={"wait": True},
+            json=body,
+        )
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise ToolError(f"Failed to upsert Qdrant collection '{collection_name}'.") from exc
 
 
 def _qdrant_point_id(value: str) -> int:
@@ -311,15 +459,6 @@ def _metadata_schema(metadata_kind: str | None) -> type[BaseModel]:
     if metadata_kind == "insurance":
         return InsuranceVectorMetadata
     return GenericVectorMetadata
-
-
-class GenericVectorMetadata(BaseModel):
-    """Validated generic metadata produced by the extraction layer."""
-
-    model_config = ConfigDict(extra="allow")
-
-    id: str = Field(..., min_length=1)
-    raw_text: str | None = None
 
 
 def _embedding_text_from_payload(metadata: dict[str, Any]) -> str:

--- a/src/services/document_upload.py
+++ b/src/services/document_upload.py
@@ -7,13 +7,8 @@ from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, ConfigDict, Field
 from starlette.datastructures import UploadFile
 
-from clients.ollama import chat_with_ollama
-from tools.document import (
-    build_document_prompt,
-    extract_pdf_text,
-    truncate_document_text,
-)
-from services.document_persistence import persist_document_if_supported
+from tools.document import extract_pdf_text, truncate_document_text
+from services.document_persistence import answer_document_prompt_from_database
 
 
 class PdfUploadRequest(BaseModel):
@@ -39,10 +34,11 @@ async def process_pdf_upload(
     upload: UploadFile,
     request: PdfUploadRequest,
 ) -> PdfUploadResponse:
-    """Extract PDF text server-side, then ask Ollama about that text.
+    """Extract PDF text, then answer through the database-first workflow.
 
-    Ollama does not receive or parse the raw PDF binary. Image-only or scanned PDFs
-    without an extractable text layer require OCR before this endpoint can answer.
+    The uploaded PDF is classified and checked against the appropriate database
+    collection before any structured extraction runs. Answers are generated from
+    the retrieved database record rather than directly from the PDF text.
     """
     _validate_pdf_upload(upload)
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -51,10 +47,11 @@ async def process_pdf_upload(
         document_text = extract_pdf_text(str(temp_path))
 
     truncated_text = truncate_document_text(document_text, max_chars=request.max_chars)
-    prompt = build_document_prompt(truncated_text, request.question)
-    model_result = await chat_with_ollama(prompt)
-    await persist_document_if_supported(document_text=truncated_text, question=request.question)
-    return PdfUploadResponse(response=model_result)
+    workflow_result = await answer_document_prompt_from_database(
+        document_text=truncated_text,
+        question=request.question,
+    )
+    return PdfUploadResponse(response=workflow_result.response)
 
 
 def _validate_pdf_upload(upload: UploadFile) -> None:

--- a/src/tools/document.py
+++ b/src/tools/document.py
@@ -25,22 +25,15 @@ def extract_pdf_text(file_path: str) -> str:
         raise ToolError("pdftotext is required but was not found in PATH") from exc
     except subprocess.CalledProcessError as exc:
         stderr = (exc.stderr or "").strip()
-        raise ToolError(f"Failed to extract text from PDF '{path.name}': {stderr or exc}") from exc
+        raise ToolError(
+            f"Failed to extract text from PDF '{path.name}': {stderr or exc}"
+        ) from exc
 
     text = result.stdout.strip()
     if not text:
         raise ToolError(f"No extractable text found in PDF: {path.name}")
 
     return text
-
-
-def build_document_prompt(document_text: str, question: str) -> str:
-    return (
-        "You are processing a PDF document. Use only the content below to answer the user question.\n\n"
-        f"User question:\n{question}\n\n"
-        "Document content:\n"
-        f"{document_text}"
-    )
 
 
 def truncate_document_text(document_text: str, max_chars: int) -> str:

--- a/tests/unit/test_document_persistence.py
+++ b/tests/unit/test_document_persistence.py
@@ -2,23 +2,27 @@ import asyncio
 import json
 
 import pytest
+from fastmcp.exceptions import ToolError
 
 from services import document_persistence
 from services.document_persistence import (
     CandidateVectorMetadata,
     InsuranceVectorMetadata,
     VectorDbMetadataError,
-    build_payload_with_ollama,
+    answer_document_prompt_from_database,
     build_vector_db_metadata,
     build_vector_db_records,
+    extract_payload_with_ollama,
     infer_pdf_domain_with_ollama,
-    persist_document_if_supported,
     persist_extracted_payload,
 )
 
 
-def test_removed_regex_metadata_builders_are_not_available() -> None:
+def test_legacy_duplicate_processing_functions_are_not_available() -> None:
     removed_names = (
+        "persist_document_if_supported",
+        "build_payload_with_ollama",
+        "build_document_prompt",
         "infer_pdf_domain",
         "build_candidate_payload",
         "build_insurance_payload",
@@ -34,6 +38,54 @@ def test_removed_regex_metadata_builders_are_not_available() -> None:
 
     for name in removed_names:
         assert not hasattr(document_persistence, name)
+
+
+def test_candidate_schema_contains_required_table_fields() -> None:
+    schema_fields = set(CandidateVectorMetadata.model_fields)
+
+    assert {
+        "id",
+        "first_name",
+        "last_name",
+        "email",
+        "phone",
+        "seniority",
+        "city",
+        "country",
+        "address",
+        "competences",
+        "previous_works",
+        "education",
+        "current_job_title",
+        "current_company",
+        "availability_date",
+        "notes",
+        "language",
+        "certifications",
+        "created_at",
+        "updated_at",
+    }.issubset(schema_fields)
+
+
+def test_insurance_schema_contains_required_table_fields() -> None:
+    schema_fields = set(InsuranceVectorMetadata.model_fields)
+
+    assert {
+        "id",
+        "candidate_id",
+        "policy_number",
+        "insurance_provider",
+        "insurance_type",
+        "policy_holder",
+        "coverage_details",
+        "start_date",
+        "end_date",
+        "premium_amount",
+        "currency",
+        "beneficiary",
+        "created_at",
+        "updated_at",
+    }.issubset(schema_fields)
 
 
 def test_build_metadata_extraction_prompt_contains_strict_schema_instructions() -> None:
@@ -52,33 +104,33 @@ def test_build_metadata_extraction_prompt_contains_strict_schema_instructions() 
     assert "The document may be written in any language." in prompt
     assert '"first_name"' in prompt
     assert '"previous_works"' in prompt
+    assert '"language"' in prompt
+    assert '"certifications"' in prompt
     assert "Jane Doe" in prompt
 
 
-def test_infer_pdf_domain_with_ollama_uses_model_json_only() -> None:
+def test_infer_pdf_domain_with_ollama_uses_model_json_only(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, object] = {}
 
     async def fake_chat_with_ollama(prompt: str) -> str:
         captured["prompt"] = prompt
         return '{"document_type":"cv"}'
 
-    original = document_persistence.chat_with_ollama
-    document_persistence.chat_with_ollama = fake_chat_with_ollama
-    try:
-        domain = asyncio.run(
-            infer_pdf_domain_with_ollama(
-                "Work experience and education",
-                "Summarize this CV",
-            )
+    monkeypatch.setattr(document_persistence, "chat_with_ollama", fake_chat_with_ollama)
+
+    domain = asyncio.run(
+        infer_pdf_domain_with_ollama(
+            "Work experience and education",
+            "Summarize this CV",
         )
-    finally:
-        document_persistence.chat_with_ollama = original
+    )
 
     assert domain == "cv"
     assert "Classify the uploaded document" in captured["prompt"]
+    assert "Do not answer the user question" in captured["prompt"]
 
 
-def test_build_payload_with_ollama_uses_schema_format_and_service_metadata(
+def test_extract_payload_with_ollama_uses_candidate_schema_format_and_service_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured: dict[str, object] = {}
@@ -91,18 +143,23 @@ def test_build_payload_with_ollama_uses_schema_format_and_service_metadata(
         return json.dumps(
             {
                 "id": None,
-                "document_hash": None,
                 "first_name": "Giulia",
                 "last_name": "Bianchi",
                 "email": "giulia@example.it",
                 "phone": None,
                 "seniority": None,
+                "city": "Roma",
+                "country": "Italia",
+                "address": None,
                 "competences": None,
                 "previous_works": [],
-                "education": ["Laurea in Informatica"],
-                "certification": [],
-                "languages": ["Italiano"],
-                "raw_text": None,
+                "education": [{"degree": "Laurea in Informatica"}],
+                "current_job_title": "Engineer",
+                "current_company": "Acme",
+                "availability_date": None,
+                "notes": None,
+                "language": ["Italiano"],
+                "certifications": [],
                 "created_at": None,
                 "updated_at": None,
             }
@@ -111,7 +168,7 @@ def test_build_payload_with_ollama_uses_schema_format_and_service_metadata(
     monkeypatch.setattr(document_persistence, "chat_with_ollama", fake_chat_with_ollama)
 
     payload = asyncio.run(
-        build_payload_with_ollama(
+        extract_payload_with_ollama(
             "Curriculum vitae\nGiulia Bianchi\nIstruzione: Laurea in Informatica",
             "candidate",
         )
@@ -123,12 +180,12 @@ def test_build_payload_with_ollama_uses_schema_format_and_service_metadata(
         "Curriculum vitae\nGiulia Bianchi\nIstruzione: Laurea in Informatica"
     )
     assert payload["first_name"] == "Giulia"
-    assert payload["education"] == ["Laurea in Informatica"]
+    assert payload["education"] == [{"degree": "Laurea in Informatica"}]
     assert captured["response_format"] == CandidateVectorMetadata.model_json_schema()
     assert "JSON Schema" in captured["prompt"]
 
 
-def test_build_payload_with_ollama_uses_insurance_schema_format(
+def test_extract_payload_with_ollama_uses_insurance_schema_format(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured: dict[str, object] = {}
@@ -141,7 +198,6 @@ def test_build_payload_with_ollama_uses_insurance_schema_format(
         return json.dumps(
             {
                 "id": None,
-                "document_hash": None,
                 "candidate_id": None,
                 "policy_number": "ITA-001",
                 "insurance_provider": "Assicurazioni Acme",
@@ -153,7 +209,6 @@ def test_build_payload_with_ollama_uses_insurance_schema_format(
                 "premium_amount": None,
                 "currency": "EUR",
                 "beneficiary": None,
-                "raw_text": None,
                 "created_at": None,
                 "updated_at": None,
             }
@@ -162,7 +217,7 @@ def test_build_payload_with_ollama_uses_insurance_schema_format(
     monkeypatch.setattr(document_persistence, "chat_with_ollama", fake_chat_with_ollama)
 
     payload = asyncio.run(
-        build_payload_with_ollama(
+        extract_payload_with_ollama(
             "Polizza numero ITA-001\nCompagnia Assicurazioni Acme",
             "insurance",
         )
@@ -189,6 +244,7 @@ def test_build_vector_metadata_uses_extracted_insurance_payload_values() -> None
         "policy_holder": {"first_name": "Amina", "last_name": "Policy"},
         "coverage_details": {"coverages": ["orthodontics"]},
         "premium_amount": 25.5,
+        "currency": "EUR",
         "raw_text": "Extracted policy text",
     }
 
@@ -209,10 +265,14 @@ def test_build_vector_metadata_uses_extracted_candidate_payload_values() -> None
         "first_name": "Amina",
         "last_name": "Payload",
         "seniority": "principal",
+        "city": "Paris",
+        "country": "France",
         "competences": {"technical": ["rust", "python"]},
-        "education": ["MSc Computer Science"],
-        "certification": ["Kubernetes Administrator"],
-        "languages": ["English", "French"],
+        "education": [{"degree": "MSc Computer Science"}],
+        "certifications": ["Kubernetes Administrator"],
+        "language": ["English", "French"],
+        "current_job_title": "Principal Engineer",
+        "current_company": "Acme",
         "raw_text": "Candidate profile",
     }
 
@@ -221,10 +281,12 @@ def test_build_vector_metadata_uses_extracted_candidate_payload_values() -> None
     assert metadata["first_name"] == "Amina"
     assert metadata["last_name"] == "Payload"
     assert metadata["seniority"] == "principal"
+    assert metadata["city"] == "Paris"
+    assert metadata["country"] == "France"
     assert metadata["competences"] == {"technical": ["rust", "python"]}
-    assert metadata["education"] == ["MSc Computer Science"]
-    assert metadata["certification"] == ["Kubernetes Administrator"]
-    assert metadata["languages"] == ["English", "French"]
+    assert metadata["education"] == [{"degree": "MSc Computer Science"}]
+    assert metadata["certifications"] == ["Kubernetes Administrator"]
+    assert metadata["language"] == ["English", "French"]
 
 
 def test_build_vector_metadata_allows_missing_optional_candidate_fields() -> None:
@@ -238,11 +300,18 @@ def test_build_vector_metadata_allows_missing_optional_candidate_fields() -> Non
     assert metadata["email"] is None
     assert metadata["phone"] is None
     assert metadata["seniority"] is None
+    assert metadata["city"] is None
+    assert metadata["country"] is None
+    assert metadata["address"] is None
     assert metadata["competences"] is None
     assert metadata["previous_works"] == []
     assert metadata["education"] == []
-    assert metadata["certification"] == []
-    assert metadata["languages"] == []
+    assert metadata["current_job_title"] is None
+    assert metadata["current_company"] is None
+    assert metadata["availability_date"] is None
+    assert metadata["notes"] is None
+    assert metadata["language"] is None
+    assert metadata["certifications"] == []
 
 
 def test_build_vector_records_chunks_embedding_text_without_changing_metadata(
@@ -296,138 +365,117 @@ def test_persist_extracted_payload_upserts_payload_metadata_without_semantic_def
     assert captured["payload"]["insurance_type"] == "vision"
     assert captured["payload"]["policy_number"] == "VIS-1"
     assert captured["payload"]["insurance_provider"] is None
-    assert captured["payload"]["currency"] == "EUR"
 
 
-def test_persist_document_if_supported_upserts_cv_payload(
+def test_database_first_workflow_uses_existing_candidate_without_extraction(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    calls: dict[str, object] = {}
-    model_responses = iter(
-        [
-            '{"document_type":"cv"}',
-            json.dumps(
-                {
-                    "id": None,
-                    "document_hash": None,
-                    "first_name": "Giulia",
-                    "last_name": "Bianchi",
-                    "email": "giulia@example.it",
-                    "phone": None,
-                    "seniority": None,
-                    "competences": None,
-                    "previous_works": [],
-                    "education": ["Laurea in Informatica"],
-                    "certification": [],
-                    "languages": ["Italiano"],
-                    "raw_text": None,
-                    "created_at": None,
-                    "updated_at": None,
-                }
-            ),
-        ]
-    )
+    calls: dict[str, object] = {"extract_count": 0}
+    existing_record = {
+        "id": "candidate-existing",
+        "document_hash": document_persistence._document_hash("CV text"),
+        "raw_text": "CV text",
+        "first_name": "Ada",
+        "last_name": "Lovelace",
+        "certifications": ["Math"],
+        "language": ["English"],
+    }
+
+    async def fake_infer(document_text: str, question: str) -> str:
+        return "cv"
+
+    async def fake_get_document_by_hash(collection_name: str, document_hash: str):
+        calls["collection"] = collection_name
+        calls["hash"] = document_hash
+        return existing_record
+
+    async def fake_extract(document_text: str, metadata_kind: str) -> dict[str, object]:
+        calls["extract_count"] = int(calls["extract_count"]) + 1
+        return {}
 
     async def fake_chat_with_ollama(
         prompt: str, *, response_format: dict[str, object] | str | None = None
     ) -> str:
-        calls.setdefault("prompts", []).append(prompt)
-        calls.setdefault("formats", []).append(response_format)
-        return next(model_responses)
+        calls["answer_prompt"] = prompt
+        return "Ada is stored in the database."
 
-    async def fake_upsert_payload(
-        collection_name: str, payload: dict[str, object]
-    ) -> None:
-        calls["upsert_collection"] = collection_name
-        calls["upsert_hash"] = payload["document_hash"]
-        calls["upsert_raw_text"] = payload["raw_text"]
-        calls["upsert_first_name"] = payload["first_name"]
-        calls["upsert_education"] = payload["education"]
-
+    monkeypatch.setattr(document_persistence, "infer_pdf_domain_with_ollama", fake_infer)
+    monkeypatch.setattr(document_persistence, "get_document_by_hash", fake_get_document_by_hash)
+    monkeypatch.setattr(document_persistence, "extract_payload_with_ollama", fake_extract)
     monkeypatch.setattr(document_persistence, "chat_with_ollama", fake_chat_with_ollama)
-    monkeypatch.setattr(document_persistence, "_upsert_payload", fake_upsert_payload)
 
-    domain = asyncio.run(
-        persist_document_if_supported(
-            "Curriculum vitae\nGiulia Bianchi\nIstruzione: Laurea in Informatica",
-            "Leggi questo CV",
-        )
-    )
+    result = asyncio.run(answer_document_prompt_from_database("CV text", "Who is this?"))
 
-    assert domain == "cv"
-    assert calls["upsert_collection"] == document_persistence.QDRANT_CANDIDATES_COLLECTION
-    assert "upsert_hash" in calls
-    assert calls["upsert_raw_text"] == (
-        "Curriculum vitae\nGiulia Bianchi\nIstruzione: Laurea in Informatica"
-    )
-    assert calls["upsert_first_name"] == "Giulia"
-    assert calls["upsert_education"] == ["Laurea in Informatica"]
-    assert "first_name" in calls["prompts"][1]
-    assert calls["formats"][1] == CandidateVectorMetadata.model_json_schema()
+    assert result.response == "Ada is stored in the database."
+    assert result.record_existed is True
+    assert calls["collection"] == document_persistence.QDRANT_CANDIDATES_COLLECTION
+    assert calls["extract_count"] == 0
+    assert "raw_text" not in calls["answer_prompt"]
+    assert "CV text" not in calls["answer_prompt"]
+    assert "Ada" in calls["answer_prompt"]
 
 
-def test_persist_document_if_supported_saves_new_insurance(
+def test_database_first_workflow_extracts_saves_retrieves_then_answers_new_insurance(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    calls: dict[str, object] = {}
-    model_responses = iter(
-        [
-            '{"document_type":"insurance"}',
-            json.dumps(
-                {
-                    "id": None,
-                    "document_hash": None,
-                    "candidate_id": None,
-                    "policy_number": "ITA-001",
-                    "insurance_provider": "Assicurazioni Acme",
-                    "insurance_type": None,
-                    "policy_holder": None,
-                    "coverage_details": None,
-                    "start_date": "2026-01-01",
-                    "end_date": None,
-                    "premium_amount": None,
-                    "currency": "EUR",
-                    "beneficiary": None,
-                    "raw_text": None,
-                    "created_at": None,
-                    "updated_at": None,
-                }
-            ),
-        ]
-    )
+    calls: dict[str, object] = {"get_count": 0, "upsert_count": 0}
+    saved_record = {
+        "id": "insurance-saved",
+        "document_hash": document_persistence._document_hash("Policy text"),
+        "raw_text": "Policy text",
+        "policy_number": "POL-1",
+        "insurance_provider": "Acme",
+    }
+
+    async def fake_infer(document_text: str, question: str) -> str:
+        return "insurance"
+
+    async def fake_get_document_by_hash(collection_name: str, document_hash: str):
+        calls["get_count"] = int(calls["get_count"]) + 1
+        return None if calls["get_count"] == 1 else saved_record
+
+    async def fake_extract(document_text: str, metadata_kind: str) -> dict[str, object]:
+        calls["extract_kind"] = metadata_kind
+        return saved_record
+
+    async def fake_upsert_payload(collection_name: str, payload: dict[str, object]) -> None:
+        calls["upsert_count"] = int(calls["upsert_count"]) + 1
+        calls["upsert_collection"] = collection_name
+        calls["upsert_payload"] = payload
 
     async def fake_chat_with_ollama(
         prompt: str, *, response_format: dict[str, object] | str | None = None
     ) -> str:
-        calls.setdefault("prompts", []).append(prompt)
-        calls.setdefault("formats", []).append(response_format)
-        return next(model_responses)
+        calls["answer_prompt"] = prompt
+        return "Policy POL-1 is stored."
 
-    async def fake_upsert_payload(
-        collection_name: str, payload: dict[str, object]
-    ) -> None:
-        calls["upsert_collection"] = collection_name
-        calls["upsert_hash"] = payload["document_hash"]
-        calls["upsert_policy_number"] = payload["policy_number"]
-        calls["upsert_start_date"] = payload["start_date"]
-
-    monkeypatch.setattr(document_persistence, "chat_with_ollama", fake_chat_with_ollama)
+    monkeypatch.setattr(document_persistence, "infer_pdf_domain_with_ollama", fake_infer)
+    monkeypatch.setattr(document_persistence, "get_document_by_hash", fake_get_document_by_hash)
+    monkeypatch.setattr(document_persistence, "extract_payload_with_ollama", fake_extract)
     monkeypatch.setattr(document_persistence, "_upsert_payload", fake_upsert_payload)
+    monkeypatch.setattr(document_persistence, "chat_with_ollama", fake_chat_with_ollama)
 
-    domain = asyncio.run(
-        persist_document_if_supported(
-            "Polizza numero: ITA-001\nCompagnia: Assicurazioni Acme\nDecorrenza: 01/01/2026",
-            "Spiega la copertura assicurativa",
-        )
-    )
+    result = asyncio.run(answer_document_prompt_from_database("Policy text", "Summarize"))
 
-    assert domain == "insurance"
+    assert result.response == "Policy POL-1 is stored."
+    assert result.record_existed is False
+    assert calls["get_count"] == 2
+    assert calls["upsert_count"] == 1
+    assert calls["extract_kind"] == "insurance"
     assert calls["upsert_collection"] == document_persistence.QDRANT_INSURANCES_COLLECTION
-    assert "upsert_hash" in calls
-    assert calls["upsert_policy_number"] == "ITA-001"
-    assert calls["upsert_start_date"] == "2026-01-01"
-    assert "start_date" in calls["prompts"][1]
-    assert calls["formats"][1] == InsuranceVectorMetadata.model_json_schema()
+    assert "raw_text" not in calls["answer_prompt"]
+    assert "Policy text" not in calls["answer_prompt"]
+    assert "POL-1" in calls["answer_prompt"]
+
+
+def test_database_first_workflow_rejects_other_documents(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_infer(document_text: str, question: str) -> str:
+        return "other"
+
+    monkeypatch.setattr(document_persistence, "infer_pdf_domain_with_ollama", fake_infer)
+
+    with pytest.raises(ToolError, match="CV or an insurance"):
+        asyncio.run(answer_document_prompt_from_database("Invoice text", "Summarize"))
 
 
 def test_build_vector_records_keeps_multipage_insurance_pdf_in_one_record(
@@ -442,7 +490,6 @@ def test_build_vector_records_keeps_multipage_insurance_pdf_in_one_record(
             "insurance_provider": "Acme Insurance",
             "raw_text": "Policy Number: MULTI-1\nProvider: Acme Insurance\fPremium EUR 10.00",
         },
-        ),
         metadata_kind="insurance",
     )
 

--- a/tests/unit/test_document_tools.py
+++ b/tests/unit/test_document_tools.py
@@ -3,14 +3,7 @@ from pathlib import Path
 import pytest
 from fastmcp.exceptions import ToolError
 
-from tools.document import build_document_prompt, extract_pdf_text, truncate_document_text
-
-
-def test_build_document_prompt_contains_question_and_document() -> None:
-    prompt = build_document_prompt("Document text", "What is this?")
-
-    assert "What is this?" in prompt
-    assert "Document text" in prompt
+from tools.document import extract_pdf_text, truncate_document_text
 
 
 def test_extract_pdf_text_raises_for_missing_file(tmp_path: Path) -> None:

--- a/tests/unit/test_document_upload.py
+++ b/tests/unit/test_document_upload.py
@@ -1,5 +1,6 @@
 import asyncio
 from io import BytesIO
+from types import SimpleNamespace
 
 import pytest
 from fastmcp.exceptions import ToolError
@@ -21,7 +22,7 @@ def make_upload(
     )
 
 
-def test_process_pdf_upload_extracts_uploaded_pdf_and_calls_ollama(
+def test_process_pdf_upload_extracts_uploaded_pdf_and_uses_database_workflow(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured: dict[str, str] = {}
@@ -30,21 +31,18 @@ def test_process_pdf_upload_extracts_uploaded_pdf_and_calls_ollama(
         captured["file_path"] = file_path
         return "Uploaded PDF text"
 
-    async def fake_chat_with_ollama(prompt: str) -> str:
-        captured["prompt"] = prompt
-        return "PDF answer"
-
-    async def fake_persist_document_if_supported(document_text: str, question: str) -> str:
-        captured["persist_document_text"] = document_text
-        captured["persist_question"] = question
-        return "cv"
+    async def fake_answer_document_prompt_from_database(
+        document_text: str, question: str
+    ) -> object:
+        captured["workflow_document_text"] = document_text
+        captured["workflow_question"] = question
+        return SimpleNamespace(response="PDF answer")
 
     monkeypatch.setattr(document_upload, "extract_pdf_text", fake_extract_pdf_text)
-    monkeypatch.setattr(document_upload, "chat_with_ollama", fake_chat_with_ollama)
     monkeypatch.setattr(
         document_upload,
-        "persist_document_if_supported",
-        fake_persist_document_if_supported,
+        "answer_document_prompt_from_database",
+        fake_answer_document_prompt_from_database,
     )
 
     response = asyncio.run(
@@ -56,10 +54,8 @@ def test_process_pdf_upload_extracts_uploaded_pdf_and_calls_ollama(
 
     assert response.response == "PDF answer"
     assert captured["file_path"].endswith(".pdf")
-    assert "Uploaded PDF text" in captured["prompt"]
-    assert "What is this document?" in captured["prompt"]
-    assert captured["persist_document_text"] == "Uploaded PDF text"
-    assert captured["persist_question"] == "What is this document?"
+    assert captured["workflow_document_text"] == "Uploaded PDF text"
+    assert captured["workflow_question"] == "What is this document?"
 
 
 def test_process_pdf_upload_rejects_non_pdf_filename() -> None:
@@ -120,10 +116,10 @@ def test_pdf_upload_endpoint_accepts_multipart_form_data(
     }
 
 
-def test_pdf_upload_openapi_documents_text_extraction_before_ollama() -> None:
+def test_pdf_upload_openapi_documents_database_first_workflow() -> None:
     from http_api import build_openapi_schema
 
     operation = build_openapi_schema()["paths"]["/api/documents/pdf"]["post"]
 
-    assert "extracted text" in operation["summary"]
-    assert "Ollama does not receive or parse raw PDF bytes" in operation["description"]
+    assert "database-first" in operation["summary"]
+    assert "database is the single source of truth" in operation["description"]


### PR DESCRIPTION
### Motivation
- Replace the previous two-step Ollama-first workflow with a single database-first pipeline so stored records become the single source of truth and duplicate PDF processing is eliminated.
- Ensure both CV and insurance PDFs follow the same flow: detect type, check DB, extract only if missing, persist once, then answer from DB.

### Description
- Added a database-first processing pipeline via `answer_document_prompt_from_database` and `extract_payload_with_ollama` in `src/services/document_persistence.py` that classifies the PDF, checks existence by `document_hash`, upserts only on miss, re-queries the DB, and generates answers from the retrieved record.
- Expanded and normalized candidate and insurance schemas in `CandidateVectorMetadata` and `InsuranceVectorMetadata` (added `language`, `certifications`, `city`, `country`, `address`, `current_job_title`, `current_company`, `availability_date`, `notes`, and insurance fields as requested) and adjusted vector-record building/validation to match the DB-first semantics.
- Rewired endpoints and tools to use the DB-first flow by updating `process_pdf_upload` in `src/services/document_upload.py` and the MCP `process_pdf` tool in `src/server.py` to call the new workflow, and removed the obsolete `build_document_prompt` helper and duplicate extract-and-answer path from `src/tools/document.py`.
- Cleaned up legacy APIs and helpers (removed `persist_document_if_supported`/`build_payload_with_ollama` usage paths), updated OpenAPI docs in `src/http_api.py` and README, and updated unit tests to assert the new behaviors.

### Testing
- Ran static compilation with `python -m compileall src tests` which succeeded without errors.
- Ran the test suite with `pytest -q` which passed (`53 passed`) with a single existing Starlette/httpx deprecation warning.
- Verified `git diff --check` and ensured no lingering dead-code references; unit tests exercise schema validation, DB-existence branching, one-time extraction + upsert, and answer-from-DB behavior and all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21480e000c8328ae5b80f6d0189915)