### PR TITLE
feat: load Ollama model from .env and default to qwen3-vl:4b

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 QDRANT_STORAGE_PATH=/home/alessandro/Desktop/data/qdrant
+OLLAMA_MODEL=qwen3-vl:4b

--- a/README.md
+++ b/README.md
@@ -123,9 +123,17 @@ LOG_FILE=logs/mcp.log LOG_MAX_BYTES=2097152 LOG_BACKUP_COUNT=10 python src/serve
 The `process_pdf` MCP tool sends extracted PDF text to Ollama. Large PDFs may take longer to complete.
 
 Environment variables:
+- `OLLAMA_MODEL` (default: `qwen3-vl:4b`; loaded from `.env` when present)
 - `OLLAMA_TIMEOUT_SECONDS` (default: `300`)
 
-Example:
+Example `.env` values:
+
+```bash
+OLLAMA_MODEL=qwen3-vl:4b
+OLLAMA_TIMEOUT_SECONDS=600
+```
+
+Example one-off override:
 
 ```bash
 OLLAMA_TIMEOUT_SECONDS=600 python src/server.py

--- a/src/config.py
+++ b/src/config.py
@@ -1,10 +1,36 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
+
+
+def _load_dotenv(env_path: Path) -> None:
+    if not env_path.is_file():
+        return
+
+    for raw_line in env_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if key.startswith("export "):
+            key = key.removeprefix("export ").strip()
+        if not key or key in os.environ:
+            continue
+
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"\"", "'"}:
+            value = value[1:-1]
+        os.environ[key] = value
+
+
+_load_dotenv(Path(__file__).resolve().parents[1] / ".env")
 
 SERVICE_NAME = "smart-ide-services"
 OLLAMA_URL = os.getenv("OLLAMA_URL", "http://127.0.0.1:11434")
-OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "qwen2.5vl:7b")
+OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "qwen3-vl:4b")
 OLLAMA_TIMEOUT_SECONDS = float(os.getenv("OLLAMA_TIMEOUT_SECONDS", "300"))
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 LOG_FILE = os.getenv("LOG_FILE", "smart-ide-services.log")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import config
+
+
+def test_load_dotenv_adds_missing_values_without_overriding_existing(
+    tmp_path: Path, monkeypatch
+) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "# local overrides",
+                "OLLAMA_MODEL=qwen3-vl:4b",
+                "export OLLAMA_URL=http://localhost:11434",
+                "LOG_LEVEL=DEBUG",
+                'LOG_FILE="quoted.log"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("OLLAMA_MODEL", raising=False)
+    monkeypatch.setenv("LOG_LEVEL", "WARNING")
+    monkeypatch.delenv("LOG_FILE", raising=False)
+    monkeypatch.delenv("OLLAMA_URL", raising=False)
+
+    config._load_dotenv(env_file)
+
+    assert os.environ["OLLAMA_MODEL"] == "qwen3-vl:4b"
+    assert os.environ["OLLAMA_URL"] == "http://localhost:11434"
+    assert os.environ["LOG_LEVEL"] == "WARNING"
+    assert os.environ["LOG_FILE"] == "quoted.log"


### PR DESCRIPTION
### Motivation

- Make the active local Ollama model configurable from a repository `.env` file instead of being hard-coded to the previous `qwen2.5vl:7b` default. 
- Load `.env` values at startup in a safe way that does not override explicitly exported environment variables to aid local development and reproducible runs.

### Description

- Add a lightweight `_load_dotenv` loader in `src/config.py` that reads the repository `.env` (supports `export` syntax and quoted values) and sets missing environment variables without overriding existing ones. 
- Change the default `OLLAMA_MODEL` to `qwen3-vl:4b` and source it from `os.getenv("OLLAMA_MODEL")` in `src/config.py`. 
- Add `OLLAMA_MODEL=qwen3-vl:4b` to the tracked `.env` and update `README.md` to document the `OLLAMA_MODEL` variable and example `.env` values. 
- Add unit test `tests/unit/test_config.py` to cover `.env` parsing behavior (quoted values, `export` syntax, and not overriding pre-existing env vars).

### Testing

- Ran `python -m compileall src tests` which completed successfully. 
- Ran `pytest -q` which passed: `54 passed` with one existing Starlette/httpx deprecation warning; the new `tests/unit/test_config.py` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a228d46d6e48328a50a4f3e286ce21c)