### PR TITLE
fix: reuse saved document metadata before classification

### DIFF
--- a/src/services/document_persistence.py
+++ b/src/services/document_persistence.py
@@ -122,30 +122,55 @@ async def answer_document_prompt_from_database(
 ) -> DocumentWorkflowResult:
     """Run the single CV/insurance pipeline with the database as source of truth.
 
-    The PDF text is used only to classify the document, compute the stable document
-    hash, and extract structured data when the corresponding database record does
-    not already exist. User-facing answers are generated exclusively from the
-    retrieved database payload, never directly from the PDF text.
+    The PDF text is used to compute the stable document hash before invoking
+    Ollama. Existing database records are answered directly from the stored
+    payload, so a previously saved PDF does not depend on another model
+    classification pass. When no record exists, the PDF text is classified and
+    extracted before the answer is generated from the retrieved database payload.
     """
+    try:
+        return await _answer_document_prompt_from_database(document_text, question)
+    except VectorDbMetadataError as exc:
+        raise ToolError(
+            "Unable to process PDF metadata with Ollama. "
+            f"{exc} Ensure the configured model supports JSON output and retry."
+        ) from exc
+
+
+async def _answer_document_prompt_from_database(
+    document_text: str, question: str
+) -> DocumentWorkflowResult:
+    document_hash = _document_hash(document_text)
+    existing_record = await _get_existing_document_record(document_hash)
+    if existing_record is not None:
+        domain, collection_name, record = existing_record
+        response = await build_answer_from_database_record(
+            question=question,
+            document_type=domain,
+            record=record,
+        )
+        return DocumentWorkflowResult(
+            response=response,
+            document_type=domain,
+            collection_name=collection_name,
+            record_id=str(record.get("id")) if record.get("id") is not None else None,
+            record_existed=True,
+        )
+
     domain = await infer_pdf_domain_with_ollama(document_text, question)
     if domain == "other":
         raise ToolError("Uploaded PDF must be either a CV or an insurance document.")
 
     metadata_kind = _metadata_kind_for_domain(domain)
     collection_name = _collection_for_metadata_kind(metadata_kind)
-    document_hash = _document_hash(document_text)
-
+    extracted_payload = await extract_payload_with_ollama(document_text, metadata_kind)
+    await _upsert_payload(collection_name, extracted_payload)
     record = await get_document_by_hash(collection_name, document_hash)
-    record_existed = record is not None
     if record is None:
-        extracted_payload = await extract_payload_with_ollama(document_text, metadata_kind)
-        await _upsert_payload(collection_name, extracted_payload)
-        record = await get_document_by_hash(collection_name, document_hash)
-        if record is None:
-            raise ToolError(
-                "Document was saved but could not be retrieved from the database. "
-                "Check Qdrant availability and collection indexing."
-            )
+        raise ToolError(
+            "Document was saved but could not be retrieved from the database. "
+            "Check Qdrant availability and collection indexing."
+        )
 
     response = await build_answer_from_database_record(
         question=question,
@@ -157,14 +182,34 @@ async def answer_document_prompt_from_database(
         document_type=domain,
         collection_name=collection_name,
         record_id=str(record.get("id")) if record.get("id") is not None else None,
-        record_existed=record_existed,
+        record_existed=False,
     )
+
+
+async def _get_existing_document_record(
+    document_hash: str,
+) -> tuple[DocumentDomain, str, dict[str, Any]] | None:
+    candidates_record = await get_document_by_hash(
+        QDRANT_CANDIDATES_COLLECTION, document_hash
+    )
+    if candidates_record is not None:
+        return "cv", QDRANT_CANDIDATES_COLLECTION, candidates_record
+
+    insurance_record = await get_document_by_hash(
+        QDRANT_INSURANCES_COLLECTION, document_hash
+    )
+    if insurance_record is not None:
+        return "insurance", QDRANT_INSURANCES_COLLECTION, insurance_record
+
+    return None
 
 
 async def infer_pdf_domain_with_ollama(document_text: str, question: str) -> DocumentDomain:
     """Classify the uploaded PDF as cv, insurance, or other."""
     prompt = _build_domain_classification_prompt(document_text, question)
-    raw_result = await chat_with_ollama(prompt)
+    raw_result = await chat_with_ollama(
+        prompt, response_format=_domain_classification_schema()
+    )
     payload = _parse_json_object(raw_result)
     domain = str(payload.get("document_type", "")).strip().lower()
     if domain not in {"cv", "insurance", "other"}:
@@ -289,6 +334,20 @@ def build_vector_db_metadata(
     return metadata
 
 
+def _domain_classification_schema() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": {
+            "document_type": {
+                "type": "string",
+                "enum": ["cv", "insurance", "other"],
+            }
+        },
+        "required": ["document_type"],
+        "additionalProperties": False,
+    }
+
+
 def _build_domain_classification_prompt(document_text: str, question: str) -> str:
     return (
         "Classify the uploaded document for database routing. "
@@ -353,15 +412,36 @@ def _build_database_answer_prompt(
 
 
 def _parse_json_object(raw_result: str) -> dict[str, Any]:
+    stripped_result = raw_result.strip()
+    if not stripped_result:
+        raise VectorDbMetadataError("Ollama returned an empty metadata response.")
+
     try:
-        parsed = json.loads(raw_result.strip())
-    except json.JSONDecodeError as exc:
-        raise VectorDbMetadataError(
-            "Ollama returned metadata that was not valid JSON."
-        ) from exc
+        parsed = json.loads(stripped_result)
+    except json.JSONDecodeError:
+        parsed = _parse_embedded_json_object(stripped_result)
+
     if not isinstance(parsed, dict):
         raise VectorDbMetadataError("Ollama metadata response must be a JSON object.")
     return parsed
+
+
+def _parse_embedded_json_object(raw_result: str) -> Any:
+    decoder = json.JSONDecoder()
+    for index, character in enumerate(raw_result):
+        if character != "{":
+            continue
+        try:
+            parsed, _ = decoder.raw_decode(raw_result[index:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+
+    raise VectorDbMetadataError(
+        "Ollama returned metadata that was not valid JSON. "
+        "Expected a JSON object such as {\"document_type\": \"cv\"}."
+    )
 
 
 def _with_service_metadata(

--- a/tests/unit/test_document_persistence.py
+++ b/tests/unit/test_document_persistence.py
@@ -112,8 +112,11 @@ def test_build_metadata_extraction_prompt_contains_strict_schema_instructions() 
 def test_infer_pdf_domain_with_ollama_uses_model_json_only(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, object] = {}
 
-    async def fake_chat_with_ollama(prompt: str) -> str:
+    async def fake_chat_with_ollama(
+        prompt: str, *, response_format: dict[str, object] | str | None = None
+    ) -> str:
         captured["prompt"] = prompt
+        captured["response_format"] = response_format
         return '{"document_type":"cv"}'
 
     monkeypatch.setattr(document_persistence, "chat_with_ollama", fake_chat_with_ollama)
@@ -126,6 +129,10 @@ def test_infer_pdf_domain_with_ollama_uses_model_json_only(monkeypatch: pytest.M
     )
 
     assert domain == "cv"
+    assert (
+        captured["response_format"]
+        == document_persistence._domain_classification_schema()
+    )
     assert "Classify the uploaded document" in captured["prompt"]
     assert "Do not answer the user question" in captured["prompt"]
 
@@ -230,9 +237,15 @@ def test_extract_payload_with_ollama_uses_insurance_schema_format(
     assert "policy_number" in captured["prompt"]
 
 
-def test_parse_json_object_rejects_non_json_wrappers() -> None:
-    with pytest.raises(VectorDbMetadataError):
-        document_persistence._parse_json_object('Here is JSON: {"document_type":"cv"}')
+def test_parse_json_object_accepts_embedded_json_wrappers() -> None:
+    assert document_persistence._parse_json_object(
+        'Here is JSON: {"document_type":"cv"}'
+    ) == {"document_type": "cv"}
+
+
+def test_parse_json_object_rejects_empty_response() -> None:
+    with pytest.raises(VectorDbMetadataError, match="empty metadata response"):
+        document_persistence._parse_json_object("  ")
 
 
 def test_build_vector_metadata_uses_extracted_insurance_payload_values() -> None:
@@ -382,7 +395,7 @@ def test_database_first_workflow_uses_existing_candidate_without_extraction(
     }
 
     async def fake_infer(document_text: str, question: str) -> str:
-        return "cv"
+        raise AssertionError("existing records should not be classified again")
 
     async def fake_get_document_by_hash(collection_name: str, document_hash: str):
         calls["collection"] = collection_name
@@ -400,7 +413,9 @@ def test_database_first_workflow_uses_existing_candidate_without_extraction(
         return "Ada is stored in the database."
 
     monkeypatch.setattr(document_persistence, "infer_pdf_domain_with_ollama", fake_infer)
-    monkeypatch.setattr(document_persistence, "get_document_by_hash", fake_get_document_by_hash)
+    monkeypatch.setattr(
+        document_persistence, "get_document_by_hash", fake_get_document_by_hash
+    )
     monkeypatch.setattr(document_persistence, "extract_payload_with_ollama", fake_extract)
     monkeypatch.setattr(document_persistence, "chat_with_ollama", fake_chat_with_ollama)
 
@@ -432,7 +447,9 @@ def test_database_first_workflow_extracts_saves_retrieves_then_answers_new_insur
 
     async def fake_get_document_by_hash(collection_name: str, document_hash: str):
         calls["get_count"] = int(calls["get_count"]) + 1
-        return None if calls["get_count"] == 1 else saved_record
+        if calls["get_count"] < 3:
+            return None
+        return saved_record
 
     async def fake_extract(document_text: str, metadata_kind: str) -> dict[str, object]:
         calls["extract_kind"] = metadata_kind
@@ -450,7 +467,9 @@ def test_database_first_workflow_extracts_saves_retrieves_then_answers_new_insur
         return "Policy POL-1 is stored."
 
     monkeypatch.setattr(document_persistence, "infer_pdf_domain_with_ollama", fake_infer)
-    monkeypatch.setattr(document_persistence, "get_document_by_hash", fake_get_document_by_hash)
+    monkeypatch.setattr(
+        document_persistence, "get_document_by_hash", fake_get_document_by_hash
+    )
     monkeypatch.setattr(document_persistence, "extract_payload_with_ollama", fake_extract)
     monkeypatch.setattr(document_persistence, "_upsert_payload", fake_upsert_payload)
     monkeypatch.setattr(document_persistence, "chat_with_ollama", fake_chat_with_ollama)
@@ -459,7 +478,7 @@ def test_database_first_workflow_extracts_saves_retrieves_then_answers_new_insur
 
     assert result.response == "Policy POL-1 is stored."
     assert result.record_existed is False
-    assert calls["get_count"] == 2
+    assert calls["get_count"] == 3
     assert calls["upsert_count"] == 1
     assert calls["extract_kind"] == "insurance"
     assert calls["upsert_collection"] == document_persistence.QDRANT_INSURANCES_COLLECTION
@@ -472,10 +491,34 @@ def test_database_first_workflow_rejects_other_documents(monkeypatch: pytest.Mon
     async def fake_infer(document_text: str, question: str) -> str:
         return "other"
 
+    async def fake_get_document_by_hash(collection_name: str, document_hash: str):
+        return None
+
     monkeypatch.setattr(document_persistence, "infer_pdf_domain_with_ollama", fake_infer)
+    monkeypatch.setattr(
+        document_persistence, "get_document_by_hash", fake_get_document_by_hash
+    )
 
     with pytest.raises(ToolError, match="CV or an insurance"):
         asyncio.run(answer_document_prompt_from_database("Invoice text", "Summarize"))
+
+
+def test_database_first_workflow_converts_metadata_errors_to_tool_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_infer(document_text: str, question: str) -> str:
+        raise VectorDbMetadataError("Ollama returned an empty metadata response.")
+
+    async def fake_get_document_by_hash(collection_name: str, document_hash: str):
+        return None
+
+    monkeypatch.setattr(document_persistence, "infer_pdf_domain_with_ollama", fake_infer)
+    monkeypatch.setattr(
+        document_persistence, "get_document_by_hash", fake_get_document_by_hash
+    )
+
+    with pytest.raises(ToolError, match="Unable to process PDF metadata"):
+        asyncio.run(answer_document_prompt_from_database("CV text", "Summarize"))
 
 
 def test_build_vector_records_keeps_multipage_insurance_pdf_in_one_record(


### PR DESCRIPTION
### Motivation
- Previously a saved PDF could still trigger an Ollama classification call that returned empty or non-JSON metadata and crashed with `VectorDbMetadataError`. 
- The intent is to prefer the database as the source of truth for already-saved documents and to surface actionable errors when the model returns invalid metadata.

### Description
- Add a DB-first workflow by computing the document hash, checking existing candidate/insurance records via `_get_existing_document_record`, and returning the stored answer when a record exists (new helper `_answer_document_prompt_from_database` and small wrapper `answer_document_prompt_from_database`).
- Convert `VectorDbMetadataError` into an API-friendly `ToolError` from `answer_document_prompt_from_database` so metadata parsing failures become clear client errors.
- Request schema-constrained JSON for classification via `_domain_classification_schema()` in `infer_pdf_domain_with_ollama` and make the JSON parser tolerant of wrapped JSON by improving `_parse_json_object` and adding `_parse_embedded_json_object` while explicitly rejecting empty responses.
- Update unit tests in `tests/unit/test_document_persistence.py` to cover saved-record reuse, classification `response_format`, embedded-JSON parsing, empty-response handling, and conversion of metadata errors to `ToolError`.

### Testing
- Ran `python -m compileall src` which completed successfully.
- Ran `pytest -q` and all tests passed: `56 passed` with `1` existing deprecation warning.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a229e635054832895978bff86a86ef0)