### PR TITLE
ci: add compose deployment workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+.githooks
+.pytest_cache
+.mypy_cache
+.ruff_cache
+.venv
+venv
+__pycache__
+*.py[cod]
+*.log
+qdrant_storage
+.env

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,3 +42,32 @@ jobs:
         uses: cycjimmy/semantic-release-action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: release
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & Push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/relewant-dev/smart-ide-services:latest
+
+      - name: Run Docker Compose
+        run: docker compose up -d

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+COPY pyproject.toml README.md ./
+COPY src ./src
+COPY skills ./skills
+
+RUN python -m pip install --upgrade pip \
+    && python -m pip install -e .
+
+EXPOSE 8000
+
+CMD ["python", "-m", "uvicorn", "http_api:app", "--app-dir", "src", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -227,19 +227,30 @@ pytest -q
 ```
 
 
-## Docker Compose (Qdrant storage path from `.env`)
+## Docker Compose
 
-A Docker Compose file is included at the repository root and reads the Qdrant host storage path from `.env` using `QDRANT_STORAGE_PATH`.
+A Docker Compose file is included at the repository root for the Smart IDE stack:
+
+- `frontend`: runs the published frontend image `ghcr.io/my-org/my-app:latest` and points common frontend API variables at `http://backend:8000`, the backend service name on the Compose network.
+- `backend`: builds this repository's `Dockerfile`, publishes port `8000`, loads `.env`, connects to Qdrant at `http://qdrant:6333`, and reaches a host-running Ollama instance through `http://host.docker.internal:11434` by default.
+- `qdrant`: stores vectors under the host path configured by `QDRANT_STORAGE_PATH`.
 
 Current `.env` example:
 
 ```bash
 QDRANT_STORAGE_PATH=./qdrant_storage
+OLLAMA_MODEL=qwen3-vl:4b
 ```
 
-Start Qdrant with:
+Start the full stack with:
 
 ```bash
-docker compose up -d qdrant
+docker compose up -d
+```
+
+For backend-only local API work, start just its dependencies and service with:
+
+```bash
+docker compose up -d qdrant backend
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,38 @@
 version: "3.9"
 
 services:
+  frontend:
+    image: ghcr.io/my-org/my-app:latest
+    container_name: smart-ide-frontend
+    depends_on:
+      - backend
+    environment:
+      API_BASE_URL: http://backend:8000
+      VITE_API_BASE_URL: http://backend:8000
+      NEXT_PUBLIC_API_BASE_URL: http://backend:8000
+    ports:
+      - "3000:3000"
+
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: ghcr.io/relewant-dev/smart-ide-services:latest
+    container_name: smart-ide-backend
+    env_file:
+      - .env
+    environment:
+      OLLAMA_URL: ${OLLAMA_URL:-http://host.docker.internal:11434}
+      OLLAMA_MODEL: ${OLLAMA_MODEL:-qwen3-vl:4b}
+      QDRANT_URL: http://qdrant:6333
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      - qdrant
+    ports:
+      - "8000:8000"
+
   qdrant:
     image: qdrant/qdrant:latest
     container_name: qdrant


### PR DESCRIPTION
### Motivation
- Provide a multi-service Docker Compose topology so frontend and backend can run together for local and CI-driven deployments.
- Enable CI to build and publish the backend image to GHCR and bring up the full Compose stack automatically on `main`.

### Description
- Added a `Dockerfile` that packages the Python backend and starts the HTTP API on port `8000` using Uvicorn. 
- Added a `.dockerignore` to keep build contexts clean and avoid including local artifacts such as `.env` and `qdrant_storage`. 
- Expanded `docker-compose.yml` to include a `frontend` service using `ghcr.io/my-org/my-app:latest`, a `backend` service built from the new `Dockerfile` with `8000:8000` mapping and `.env` support, and preserved the existing `qdrant` service and volume mapping. 
- Added a `deploy` job to `.github/workflows/ci.yaml` that runs on `ubuntu-latest` after the existing `release` job, logs in to GHCR using `docker/login-action@v3`, builds and pushes the backend image with `docker/build-push-action@v6` (tag `ghcr.io/relewant-dev/smart-ide-services:latest`), and runs `docker compose up -d`.
- Updated `README.md` Docker Compose documentation to describe the frontend/backend/Qdrant stack and how to start the full or backend-only stack.

### Testing
- Ran `python -m compileall src` and it completed successfully. 
- Ran `pytest -q` and all tests passed (`56 passed`, `1` existing deprecation warning). 
- Validated YAML parsing for `.github/workflows/ci.yaml` and `docker-compose.yml` via a small Python check using `yaml.safe_load`, which succeeded. 
- Ran `git diff --check` with no issues. 
- Attempted `docker compose config` in the execution environment but it failed because Docker is not installed (`docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a266d861d44832894c2e7afd84ffc10)