### PR TITLE
ci: add Proxmox deployment job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,3 +68,39 @@ jobs:
           context: .
           push: true
           tags: ghcr.io/relewant-dev/smart-ide-services:latest
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Install WireGuard and SSH tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wireguard openresolv openssh-client sshpass
+
+      - name: Configure VPN
+        run: |
+          sudo mkdir -p /etc/wireguard
+          echo "${{ secrets.WG_CONFIG }}" | sudo tee /etc/wireguard/wg0.conf > /dev/null
+          sudo chmod 600 /etc/wireguard/wg0.conf
+          sudo wg-quick up wg0
+
+      - name: Test VPN connection
+        run: ping -c 3 192.168.100.206
+
+      # Password-based SSH is supported for this deployment, but SSH keys would be safer.
+      - name: Deploy on Proxmox machine
+        run: |
+          sshpass -p "${{ secrets.PROXMOX_PASSWORD }}" ssh -o StrictHostKeyChecking=no administrator@192.168.100.206 << 'EOF'
+            cd /home/alessandro/Desktop/smart-ide/smart-ide-services
+
+            echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u relewant-dev --password-stdin
+
+            docker compose pull
+            docker compose up -d --build
+          EOF

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   backend:
     build:


### PR DESCRIPTION
### Motivation
- Automate deployment of the built backend image `ghcr.io/relewant-dev/smart-ide-services:latest` to the Proxmox host after successful builds on `main`.
- Ensure the runner connects to the private network first by bringing up the WireGuard interface so it can reach the Proxmox machine at `192.168.100.206`.
- Keep sensitive data out of the repository by using GitHub Secrets for VPN config, Proxmox password, and GHCR PAT.

### Description
- Added a new `deploy` job in `.github/workflows/ci.yaml` that runs `on: push` to `main`, `needs: build`, and sets `permissions: contents: read` and `packages: read`.
- The `deploy` job installs WireGuard and SSH tooling with `sudo apt-get install -y wireguard openresolv openssh-client sshpass` and then writes `secrets.WG_CONFIG` to `/etc/wireguard/wg0.conf` and runs `wg-quick up wg0` to bring up the VPN.
- The job tests connectivity with `ping -c 3 192.168.100.206` and then uses `sshpass` with `secrets.PROXMOX_PASSWORD` to SSH to `administrator@192.168.100.206`, `cd` into `/home/alessandro/Desktop/smart-ide/smart-ide-services`, logs into GHCR using `secrets.GHCR_PAT`, and runs `docker compose pull` and `docker compose up -d --build` on the remote host.
- Removed the obsolete `version: "3.9"` line from `docker-compose.yml` and added a comment in the workflow noting that SSH keys are safer than password-based SSH.

### Testing
- Parsed `.github/workflows/ci.yaml` and `docker-compose.yml` successfully using `yaml.safe_load(...)` to validate YAML structure.
- Ran `python -m compileall src` successfully to validate Python compilation of the codebase.
- Ran `pytest` and all unit tests passed (`56 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a268b3a62148328a93b009917ed86fc)