### PR TITLE
feat: add anonymized CV PDF export endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
   "python-multipart>=0.0.9,<1",
   "starlette>=0.37.0,<2",
   "uvicorn[standard]>=0.30.0,<1",
+  "pypdf>=4.0.0,<7",
+  "reportlab>=4.0.0,<5",
 ]
 
 [project.scripts]

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -64,6 +64,7 @@ else:
     from starlette.responses import HTMLResponse, JSONResponse, Response
     from starlette.routing import Route
 
+    from routers.cv_export import router as cv_export_router
     from routers.document import router as document_router
     from routers.prompt import router as prompt_router
     from services.document_upload import PdfUploadResponse
@@ -78,6 +79,47 @@ else:
                 "description": "HTTP API for frontend prompt routing and database-first PDF answers.",
             },
             "paths": {
+                "/api/cv/anonymized-pdf": {
+                    "post": {
+                        "tags": ["cv"],
+                        "summary": "Upload a CV PDF and receive an anonymized version rendered on ReleWant letterhead.",
+                        "description": "Extracts CV PDF text, asks Ollama to anonymize personally identifiable information, renders the anonymized content onto stationery/relewant-sa-letterhead.pdf, streams the generated PDF, and deletes temporary files after delivery.",
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "multipart/form-data": {
+                                    "schema": {
+                                        "type": "object",
+                                        "required": ["file"],
+                                        "properties": {
+                                            "file": {
+                                                "type": "string",
+                                                "format": "binary",
+                                                "description": "CV PDF to anonymize and render.",
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "responses": {
+                            "200": {
+                                "description": "Generated anonymized CV PDF.",
+                                "content": {
+                                    "application/pdf": {
+                                        "schema": {"type": "string", "format": "binary"}
+                                    }
+                                },
+                            },
+                            "400": {
+                                "description": "Invalid upload, extraction failure, Ollama failure, missing template, or PDF rendering failure."
+                            },
+                            "500": {
+                                "description": "Temporary file creation or file delivery failure."
+                            },
+                        },
+                    }
+                },
                 "/api/documents/pdf": {
                     "post": {
                         "tags": ["documents"],
@@ -209,6 +251,7 @@ else:
                 "service": SERVICE_NAME,
                 "routes": [
                     "POST /api/documents/pdf",
+                    "POST /api/cv/anonymized-pdf",
                     "POST /api/prompts/execute",
                 ],
                 "docs": "Open Swagger UI at /docs or fetch the OpenAPI schema at /openapi.json.",
@@ -223,6 +266,7 @@ else:
                 Route("/docs", swagger_docs, methods=["GET"]),
                 Route("/openapi.json", openapi_schema, methods=["GET"]),
                 *document_router.routes,
+                *cv_export_router.routes,
                 *prompt_router.routes,
             ],
         )

--- a/src/routers/cv_export.py
+++ b/src/routers/cv_export.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+from time import perf_counter
+
+from fastmcp.exceptions import ToolError
+from pydantic import ValidationError
+from starlette.background import BackgroundTask
+from starlette.datastructures import UploadFile
+from starlette.requests import Request
+from starlette.responses import FileResponse, JSONResponse, Response
+from starlette.routing import Route, Router
+from starlette.status import HTTP_400_BAD_REQUEST, HTTP_500_INTERNAL_SERVER_ERROR
+
+from logging_config import get_logger
+from services.cv_anonymization import anonymize_cv_text
+from services.cv_extraction import extract_cv_text_from_upload
+from services.cv_pdf_rendering import render_anonymized_cv_pdf
+
+logger = get_logger()
+
+
+async def post_anonymized_cv_export(request: Request) -> Response:
+    temp_dir: Path | None = None
+    try:
+        form = await request.form()
+        upload = form.get("file")
+        if not isinstance(upload, UploadFile):
+            raise ToolError("multipart field 'file' is required and must contain a CV PDF upload.")
+
+        logger.info("cv_export_upload_received filename=%s content_type=%s", upload.filename, upload.content_type)
+        extracted_text = await extract_cv_text_from_upload(upload)
+        logger.info("cv_export_text_extraction_completed filename=%s extracted_chars=%s", upload.filename, len(extracted_text))
+
+        logger.info("cv_export_ollama_anonymization_started filename=%s", upload.filename)
+        anonymized_text = await anonymize_cv_text(extracted_text)
+        logger.info("cv_export_ollama_anonymization_completed filename=%s anonymized_chars=%s", upload.filename, len(anonymized_text))
+
+        temp_dir = Path(tempfile.mkdtemp(prefix="anonymized-cv-"))
+        output_path = temp_dir / "anonymized-cv.pdf"
+        logger.info("cv_export_pdf_generation_started output_path=%s", output_path)
+        render_anonymized_cv_pdf(anonymized_text, output_path)
+        logger.info("cv_export_pdf_generation_completed output_path=%s", output_path)
+
+        return FileResponse(
+            output_path,
+            media_type="application/pdf",
+            filename="anonymized-cv.pdf",
+            background=BackgroundTask(_delete_temp_dir, temp_dir),
+        )
+    except ValidationError as exc:
+        logger.exception("cv_export_validation_failed")
+        if temp_dir is not None:
+            _delete_temp_dir(temp_dir)
+        return JSONResponse({"detail": exc.errors()}, status_code=422)
+    except ToolError as exc:
+        logger.exception("cv_export_failed error=%s", exc)
+        if temp_dir is not None:
+            _delete_temp_dir(temp_dir)
+        return JSONResponse({"detail": str(exc)}, status_code=HTTP_400_BAD_REQUEST)
+    except OSError as exc:
+        logger.exception("cv_export_file_delivery_or_tempfile_failed error=%s", exc)
+        if temp_dir is not None:
+            _delete_temp_dir(temp_dir)
+        return JSONResponse(
+            {"detail": f"Failed to create or deliver generated CV PDF: {exc}"},
+            status_code=HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+
+
+def _delete_temp_dir(temp_dir: Path) -> None:
+    shutil.rmtree(temp_dir, ignore_errors=True)
+    logger.info("cv_export_temporary_file_deleted temp_dir=%s", temp_dir)
+
+
+router = Router(routes=[Route("/api/cv/anonymized-pdf", post_anonymized_cv_export, methods=["POST"])])

--- a/src/services/cv_anonymization.py
+++ b/src/services/cv_anonymization.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from fastmcp.exceptions import ToolError
+
+from clients.ollama import chat_with_ollama
+
+CV_ANONYMIZATION_PROMPT_TEMPLATE = """You anonymize CV content for PDF export.
+
+Privacy rules:
+- Remove phone numbers.
+- Remove email addresses.
+- Remove street names and house numbers.
+- Replace the candidate's full name with initials only, for example "Gabriele Di Somma" becomes "G. D. S." and "Mario Rossi" becomes "M. R.".
+- Keep only the city from any address, for example "Via Roma 10, 6900 Lugano, Switzerland" becomes "Lugano".
+- Preserve professional experience, education, skills, certifications, languages, projects, technical competencies, and professional summary.
+- Remove or transform only personally identifiable information.
+
+Output rules:
+- Return only the anonymized CV content.
+- Do not add commentary, explanations, notes, markdown, or extra text.
+
+CV content:
+{cv_text}
+"""
+
+
+async def anonymize_cv_text(cv_text: str) -> str:
+    cleaned_text = cv_text.strip()
+    if not cleaned_text:
+        raise ToolError("Extracted CV text is empty and cannot be anonymized.")
+
+    response = await chat_with_ollama(
+        CV_ANONYMIZATION_PROMPT_TEMPLATE.format(cv_text=cleaned_text)
+    )
+    anonymized_text = response.strip()
+    if not anonymized_text:
+        raise ToolError("Ollama returned an empty anonymized CV response.")
+    return anonymized_text

--- a/src/services/cv_extraction.py
+++ b/src/services/cv_extraction.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from fastmcp.exceptions import ToolError
+from starlette.datastructures import UploadFile
+
+from tools.document import extract_pdf_text
+
+PDF_CONTENT_TYPES = {"application/pdf", "application/x-pdf"}
+
+
+def validate_cv_pdf_upload(upload: UploadFile) -> None:
+    filename = upload.filename or ""
+    content_type = upload.content_type or ""
+    if not filename:
+        raise ToolError("multipart field 'file' is required and must contain a PDF upload.")
+    if not filename.lower().endswith(".pdf"):
+        raise ToolError("Uploaded CV must use a .pdf filename.")
+    if content_type and content_type not in PDF_CONTENT_TYPES:
+        raise ToolError(f"Uploaded CV must be a PDF, got content type: {content_type}")
+
+
+async def extract_cv_text_from_upload(upload: UploadFile) -> str:
+    """Persist an uploaded CV PDF temporarily and extract its text."""
+    validate_cv_pdf_upload(upload)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir) / "cv-upload.pdf"
+        bytes_written = await _write_upload_to_file(upload, temp_path)
+        if bytes_written == 0:
+            raise ToolError("Uploaded CV PDF is empty.")
+        return extract_pdf_text(str(temp_path))
+
+
+async def _write_upload_to_file(upload: UploadFile, destination: Path) -> int:
+    try:
+        bytes_written = 0
+        with destination.open("wb") as file_obj:
+            while chunk := await upload.read(1024 * 1024):
+                bytes_written += len(chunk)
+                file_obj.write(chunk)
+        return bytes_written
+    except OSError as exc:
+        raise ToolError(f"Failed to create temporary CV upload file: {exc}") from exc
+    finally:
+        await upload.close()

--- a/src/services/cv_pdf_rendering.py
+++ b/src/services/cv_pdf_rendering.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import copy
+import textwrap
+from pathlib import Path
+
+from fastmcp.exceptions import ToolError
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_TEMPLATE_PATH = REPOSITORY_ROOT / "stationery" / "relewant-sa-letterhead.pdf"
+
+
+def render_anonymized_cv_pdf(
+    anonymized_text: str,
+    output_path: Path,
+    *,
+    template_path: Path = DEFAULT_TEMPLATE_PATH,
+) -> Path:
+    """Render anonymized CV text onto the ReleWant letterhead template."""
+    cleaned_text = anonymized_text.strip()
+    if not cleaned_text:
+        raise ToolError("Anonymized CV content is empty and cannot be rendered.")
+    if not template_path.is_file():
+        raise ToolError(f"ReleWant letterhead template not found: {template_path}")
+
+    try:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        from pypdf import PdfReader, PdfWriter
+
+        template_reader = PdfReader(str(template_path))
+        if not template_reader.pages:
+            raise ToolError("ReleWant letterhead template does not contain any pages.")
+
+        page_width = float(template_reader.pages[0].mediabox.width or 595.2755905511812)
+        page_height = float(template_reader.pages[0].mediabox.height or 841.8897637795277)
+        overlay_path = output_path.with_suffix(".overlay.pdf")
+        _write_text_overlay(cleaned_text, overlay_path, page_width, page_height)
+
+        overlay_reader = PdfReader(str(overlay_path))
+        writer = PdfWriter()
+        for overlay_page in overlay_reader.pages:
+            base_page = copy.deepcopy(template_reader.pages[0])
+            base_page.merge_page(overlay_page)
+            writer.add_page(base_page)
+
+        with output_path.open("wb") as output_file:
+            writer.write(output_file)
+        overlay_path.unlink(missing_ok=True)
+        return output_path
+    except ToolError:
+        raise
+    except Exception as exc:
+        raise ToolError(f"Failed to render anonymized CV PDF: {exc}") from exc
+
+
+def _write_text_overlay(
+    text: str, overlay_path: Path, page_width: float, page_height: float
+) -> None:
+    from reportlab.lib.colors import HexColor
+    from reportlab.lib.units import mm
+    from reportlab.pdfgen import canvas
+
+    pdf = canvas.Canvas(str(overlay_path), pagesize=(page_width, page_height))
+    pdf.setTitle("Anonymized CV")
+
+    left_margin = 22 * mm
+    right_margin = 22 * mm
+    top_margin = 42 * mm
+    bottom_margin = 22 * mm
+    font_name = "Helvetica"
+    font_size = 10
+    line_height = 14
+    chars_per_line = max(
+        40, int((page_width - left_margin - right_margin) / (font_size * 0.52))
+    )
+
+    y = page_height - top_margin
+    pdf.setFillColor(HexColor("#222222"))
+    pdf.setFont(font_name, font_size)
+
+    for paragraph in text.splitlines():
+        wrapped_lines = textwrap.wrap(paragraph, width=chars_per_line) if paragraph.strip() else [""]
+        for line in wrapped_lines:
+            if y <= bottom_margin:
+                pdf.showPage()
+                pdf.setFillColor(HexColor("#222222"))
+                pdf.setFont(font_name, font_size)
+                y = page_height - top_margin
+            pdf.drawString(left_margin, y, line)
+            y -= line_height
+    pdf.save()

--- a/tests/unit/test_cv_export.py
+++ b/tests/unit/test_cv_export.py
@@ -1,0 +1,159 @@
+import asyncio
+from io import BytesIO
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastmcp.exceptions import ToolError
+from starlette.datastructures import Headers, UploadFile
+
+from services import cv_anonymization, cv_extraction, cv_pdf_rendering
+
+
+def make_upload(
+    filename: str = "cv.pdf",
+    content_type: str = "application/pdf",
+    content: bytes = b"%PDF-1.7",
+) -> UploadFile:
+    return UploadFile(
+        BytesIO(content),
+        filename=filename,
+        headers=Headers({"content-type": content_type}),
+    )
+
+
+def test_extract_cv_text_from_upload_writes_pdf_and_extracts_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_extract_pdf_text(file_path: str) -> str:
+        captured["file_path"] = file_path
+        captured["exists_during_extraction"] = Path(file_path).is_file()
+        return "Gabriele Di Somma\nSenior Developer"
+
+    monkeypatch.setattr(cv_extraction, "extract_pdf_text", fake_extract_pdf_text)
+
+    result = asyncio.run(cv_extraction.extract_cv_text_from_upload(make_upload()))
+
+    assert result == "Gabriele Di Somma\nSenior Developer"
+    assert captured["file_path"].endswith("cv-upload.pdf")
+    assert captured["exists_during_extraction"] is True
+
+
+def test_extract_cv_text_from_upload_rejects_invalid_pdf() -> None:
+    with pytest.raises(ToolError, match=".pdf filename"):
+        asyncio.run(cv_extraction.extract_cv_text_from_upload(make_upload(filename="cv.txt", content_type="text/plain")))
+
+
+def test_anonymize_cv_text_uses_ollama_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, str] = {}
+
+    async def fake_chat_with_ollama(prompt: str, **_: object) -> str:
+        captured["prompt"] = prompt
+        return "G. D. S.\nLugano\nSenior Developer"
+
+    monkeypatch.setattr(cv_anonymization, "chat_with_ollama", fake_chat_with_ollama)
+
+    result = asyncio.run(cv_anonymization.anonymize_cv_text("Gabriele Di Somma\ngabriele@example.com\nVia Roma 10, Lugano"))
+
+    assert result == "G. D. S.\nLugano\nSenior Developer"
+    assert "Remove phone numbers" in captured["prompt"]
+    assert "Remove email addresses" in captured["prompt"]
+    assert "Replace the candidate's full name with initials only" in captured["prompt"]
+    assert "Return only the anonymized CV content" in captured["prompt"]
+
+
+def test_anonymize_cv_text_rejects_empty_ollama_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_chat_with_ollama(prompt: str, **_: object) -> str:
+        return "   "
+
+    monkeypatch.setattr(cv_anonymization, "chat_with_ollama", fake_chat_with_ollama)
+
+    with pytest.raises(ToolError, match="empty anonymized CV response"):
+        asyncio.run(cv_anonymization.anonymize_cv_text("CV text"))
+
+
+def test_render_anonymized_cv_pdf_requires_template(tmp_path: Path) -> None:
+    with pytest.raises(ToolError, match="template not found"):
+        cv_pdf_rendering.render_anonymized_cv_pdf(
+            "M. R.\nEngineer",
+            tmp_path / "out.pdf",
+            template_path=tmp_path / "missing-template.pdf",
+        )
+
+
+def test_render_anonymized_cv_pdf_writes_output_with_template(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    template_path = tmp_path / "template.pdf"
+    template_path.write_bytes(b"template")
+    output_path = tmp_path / "out.pdf"
+
+    class FakePage:
+        mediabox = SimpleNamespace(width=595, height=842)
+
+        def merge_page(self, other: object) -> None:
+            self.other = other
+
+    class FakeReader:
+        def __init__(self, path: str) -> None:
+            self.pages = [FakePage()]
+
+    class FakeWriter:
+        def __init__(self) -> None:
+            self.pages = []
+
+        def add_page(self, page: object) -> None:
+            self.pages.append(page)
+
+        def write(self, file_obj: object) -> None:
+            file_obj.write(b"%PDF fake anonymized cv")
+
+    import sys
+
+    monkeypatch.setitem(sys.modules, "pypdf", SimpleNamespace(PdfReader=FakeReader, PdfWriter=FakeWriter))
+    monkeypatch.setattr(cv_pdf_rendering, "_write_text_overlay", lambda text, overlay_path, width, height: overlay_path.write_bytes(b"overlay"))
+
+    result = cv_pdf_rendering.render_anonymized_cv_pdf("M. R.\nEngineer", output_path, template_path=template_path)
+
+    assert result == output_path
+    assert output_path.read_bytes() == b"%PDF fake anonymized cv"
+    assert not output_path.with_suffix(".overlay.pdf").exists()
+
+
+def test_anonymized_cv_endpoint_returns_pdf_and_deletes_temp_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    from starlette.applications import Starlette
+    from starlette.testclient import TestClient
+
+    from routers import cv_export as cv_export_router
+
+    captured: dict[str, object] = {}
+
+    async def fake_extract(upload: UploadFile) -> str:
+        captured["filename"] = upload.filename
+        return "Raw CV"
+
+    async def fake_anonymize(text: str) -> str:
+        captured["text"] = text
+        return "Anonymized CV"
+
+    def fake_render(text: str, output_path: Path) -> Path:
+        captured["anonymized"] = text
+        output_path.write_bytes(b"%PDF anonymized")
+        captured["temp_dir"] = output_path.parent
+        return output_path
+
+    monkeypatch.setattr(cv_export_router, "extract_cv_text_from_upload", fake_extract)
+    monkeypatch.setattr(cv_export_router, "anonymize_cv_text", fake_anonymize)
+    monkeypatch.setattr(cv_export_router, "render_anonymized_cv_pdf", fake_render)
+
+    client = TestClient(Starlette(routes=cv_export_router.router.routes))
+    response = client.post(
+        "/api/cv/anonymized-pdf",
+        files={"file": ("cv.pdf", b"%PDF-1.7", "application/pdf")},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/pdf"
+    assert response.content == b"%PDF anonymized"
+    assert captured["filename"] == "cv.pdf"
+    assert captured["text"] == "Raw CV"
+    assert captured["anonymized"] == "Anonymized CV"
+    assert not captured["temp_dir"].exists()


### PR DESCRIPTION
### Motivation
- Provide an endpoint to accept a CV PDF, anonymize PII via Ollama, and render the anonymized CV onto the ReleWant letterhead template for immediate download.
- Keep generated CVs ephemeral by writing PDFs to a temporary directory and deleting them after successful delivery.
- Maintain separation of concerns by splitting extraction, anonymization, and PDF rendering into dedicated services consistent with the project's architecture.

### Description
- Added a new Starlette router `POST /api/cv/anonymized-pdf` implemented in `src/routers/cv_export.py` that orchestrates extraction, Ollama anonymization, rendering on `stationery/relewant-sa-letterhead.pdf`, streaming, and cleanup.
- Implemented a CV extraction service in `src/services/cv_extraction.py` that validates uploads, writes the uploaded PDF to a temporary file, calls the existing `extract_pdf_text`, and handles errors.
- Implemented a CV anonymization service in `src/services/cv_anonymization.py` that sends a dedicated prompt to Ollama to remove phone numbers, emails, street addresses, convert full names to initials, keep only city, preserve professional content, and return only the anonymized CV content.
- Implemented PDF rendering in `src/services/cv_pdf_rendering.py` that loads the ReleWant letterhead, produces a text overlay using `reportlab`, merges overlays into the template with `pypdf`, and writes the final PDF.
- Updated OpenAPI schema in `src/http_api.py` to document the new endpoint and added runtime dependencies `pypdf` and `reportlab` to `pyproject.toml`.
- Added unit and endpoint tests in `tests/unit/test_cv_export.py` and instrumented structured logging and error handling for the main failure modes and lifecycle events.

### Testing
- Ran `python -m compileall src` which succeeded and validated module imports and bytecode compilation across the modified files.
- Ran `pytest` and all tests passed in CI locally with `63 passed, 1 warning` which includes the newly added `tests/unit/test_cv_export.py`.
- Attempted `python -m pip install -e .` to validate packaging, but dependency installation failed in this environment due to a package index/proxy returning `403 Forbidden` while resolving build dependencies (this did not affect the unit test run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2facab134c8328ad9dbf3d9c9c8b31)