### PR TITLE
fix: remove names and intro sentence from CV anonymization

### DIFF
--- a/src/services/cv_anonymization.py
+++ b/src/services/cv_anonymization.py
@@ -10,13 +10,14 @@ Privacy rules:
 - Remove phone numbers.
 - Remove email addresses.
 - Remove street names and house numbers.
-- Replace the candidate's full name with initials only, for example "Gabriele Di Somma" becomes "G. D. S." and "Mario Rossi" becomes "M. R.".
+- Remove the candidate's first name and surname entirely; do not replace names with initials or placeholders.
 - Keep only the city from any address, for example "Via Roma 10, 6900 Lugano, Switzerland" becomes "Lugano".
 - Preserve professional experience, education, skills, certifications, languages, projects, technical competencies, and professional summary.
 - Remove or transform only personally identifiable information.
 
 Output rules:
 - Return only the anonymized CV content.
+- Do not start with an introductory sentence such as "Here is the anonymized CV content for PDF export:".
 - Do not add commentary, explanations, notes, markdown, or extra text.
 
 CV content:
@@ -32,7 +33,14 @@ async def anonymize_cv_text(cv_text: str) -> str:
     response = await chat_with_ollama(
         CV_ANONYMIZATION_PROMPT_TEMPLATE.format(cv_text=cleaned_text)
     )
-    anonymized_text = response.strip()
+    anonymized_text = _remove_introductory_sentence(response.strip())
     if not anonymized_text:
         raise ToolError("Ollama returned an empty anonymized CV response.")
+    return anonymized_text
+
+
+def _remove_introductory_sentence(anonymized_text: str) -> str:
+    intro = "Here is the anonymized CV content for PDF export:"
+    if anonymized_text.startswith(intro):
+        return anonymized_text.removeprefix(intro).lstrip()
     return anonymized_text

--- a/tests/unit/test_cv_export.py
+++ b/tests/unit/test_cv_export.py
@@ -49,17 +49,30 @@ def test_anonymize_cv_text_uses_ollama_prompt(monkeypatch: pytest.MonkeyPatch) -
 
     async def fake_chat_with_ollama(prompt: str, **_: object) -> str:
         captured["prompt"] = prompt
-        return "G. D. S.\nLugano\nSenior Developer"
+        return "Lugano\nSenior Developer"
 
     monkeypatch.setattr(cv_anonymization, "chat_with_ollama", fake_chat_with_ollama)
 
     result = asyncio.run(cv_anonymization.anonymize_cv_text("Gabriele Di Somma\ngabriele@example.com\nVia Roma 10, Lugano"))
 
-    assert result == "G. D. S.\nLugano\nSenior Developer"
+    assert result == "Lugano\nSenior Developer"
     assert "Remove phone numbers" in captured["prompt"]
     assert "Remove email addresses" in captured["prompt"]
-    assert "Replace the candidate's full name with initials only" in captured["prompt"]
+    assert "Remove the candidate's first name and surname entirely" in captured["prompt"]
+    assert "do not replace names with initials or placeholders" in captured["prompt"]
     assert "Return only the anonymized CV content" in captured["prompt"]
+    assert "Do not start with an introductory sentence" in captured["prompt"]
+
+
+def test_anonymize_cv_text_removes_introductory_sentence(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_chat_with_ollama(prompt: str, **_: object) -> str:
+        return "Here is the anonymized CV content for PDF export:\nLugano\nSenior Developer"
+
+    monkeypatch.setattr(cv_anonymization, "chat_with_ollama", fake_chat_with_ollama)
+
+    result = asyncio.run(cv_anonymization.anonymize_cv_text("Gabriele Di Somma"))
+
+    assert result == "Lugano\nSenior Developer"
 
 
 def test_anonymize_cv_text_rejects_empty_ollama_response(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
### Motivation
- The anonymization flow must not output an introductory sentence and must remove candidate names entirely rather than replacing them with initials to meet the requested privacy requirements.

### Description
- Updated `CV_ANONYMIZATION_PROMPT_TEMPLATE` in `src/services/cv_anonymization.py` to require removing the candidate's first name and surname entirely and to forbid the introductory sentence `Here is the anonymized CV content for PDF export:`.
- Added a defensive helper function `_remove_introductory_sentence` and wired it into `anonymize_cv_text` to strip the forbidden intro if the model still returns it.
- Adjusted unit tests in `tests/unit/test_cv_export.py` to assert the new prompt requirements, updated expected anonymized output, and added a test that verifies the introductory sentence is removed when returned by the model.

### Testing
- Ran `python -m compileall src` which completed successfully.
- Ran the CV export unit tests with `PYTHONPATH=src pytest tests/unit/test_cv_export.py` and they passed (8 tests, 1 existing Starlette deprecation warning).
- Ran the full unit test suite with `PYTHONPATH=src pytest` and it passed (64 tests, 1 existing Starlette deprecation warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fb408758883288cd2520590d6892e)