### PR TITLE
fix: tighten CV anonymization prompt

### DIFF
--- a/src/services/cv_anonymization.py
+++ b/src/services/cv_anonymization.py
@@ -10,14 +10,15 @@ Privacy rules:
 - Remove phone numbers.
 - Remove email addresses.
 - Remove street names and house numbers.
-- Remove the candidate's first name and surname entirely; do not replace names with initials or placeholders.
+- Remove the candidate's first name and surname completely; do not leave, replace, initialize, or pseudonymize any part of the candidate name.
 - Keep only the city from any address, for example "Via Roma 10, 6900 Lugano, Switzerland" becomes "Lugano".
 - Preserve professional experience, education, skills, certifications, languages, projects, technical competencies, and professional summary.
 - Remove or transform only personally identifiable information.
 
 Output rules:
 - Return only the anonymized CV content.
-- Do not start with an introductory sentence such as "Here is the anonymized CV content for PDF export:".
+- The response must start directly with the CV content.
+- Do not include any introductory text before the CV content.
 - Do not add commentary, explanations, notes, markdown, or extra text.
 
 CV content:

--- a/tests/unit/test_cv_export.py
+++ b/tests/unit/test_cv_export.py
@@ -58,10 +58,12 @@ def test_anonymize_cv_text_uses_ollama_prompt(monkeypatch: pytest.MonkeyPatch) -
     assert result == "Lugano\nSenior Developer"
     assert "Remove phone numbers" in captured["prompt"]
     assert "Remove email addresses" in captured["prompt"]
-    assert "Remove the candidate's first name and surname entirely" in captured["prompt"]
-    assert "do not replace names with initials or placeholders" in captured["prompt"]
+    assert "Remove the candidate's first name and surname completely" in captured["prompt"]
+    assert "do not leave, replace, initialize, or pseudonymize" in captured["prompt"]
     assert "Return only the anonymized CV content" in captured["prompt"]
-    assert "Do not start with an introductory sentence" in captured["prompt"]
+    assert "The response must start directly with the CV content" in captured["prompt"]
+    assert "Do not include any introductory text" in captured["prompt"]
+    assert "Here is the anonymized CV content for PDF export" not in captured["prompt"]
 
 
 def test_anonymize_cv_text_removes_introductory_sentence(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
### Motivation
- Improve privacy guarantees for anonymized CV exports by removing any chance the model preserves or partially reveals candidate names and by preventing model-generated preambles or explanatory text.

### Description
- Updated the Ollama prompt in `src/services/cv_anonymization.py` to require complete removal of the candidate first name and surname and to require the response to start directly with the CV content with no introductory text.
- Strengthened output rules to forbid any commentary, markdown, notes, or extra text and adjusted unit assertions in `tests/unit/test_cv_export.py` to reflect the new prompt wording and to assert the disallowed introductory phrase is not present.
- Committed the changes with the Conventional Commit message `fix: tighten CV anonymization prompt`.

### Testing
- Ran `python -m compileall src` which completed successfully.
- Ran `pytest` which passed: `64 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fb735d688832882fee14a6708b7d6)