### PR TITLE
fix: prevent duplicate anonymized CV pages

### DIFF
--- a/src/services/cv_pdf_rendering.py
+++ b/src/services/cv_pdf_rendering.py
@@ -37,20 +37,47 @@ def render_anonymized_cv_pdf(
         _write_text_overlay(cleaned_text, overlay_path, page_width, page_height)
 
         overlay_reader = PdfReader(str(overlay_path))
+        overlay_pages = _deduplicate_identical_overlay_pages(list(overlay_reader.pages))
+        if not overlay_pages:
+            raise ToolError("Generated anonymized CV overlay does not contain any pages.")
         writer = PdfWriter()
-        for overlay_page in overlay_reader.pages:
+        for overlay_page in overlay_pages:
             base_page = copy.deepcopy(template_reader.pages[0])
             base_page.merge_page(overlay_page)
             writer.add_page(base_page)
 
         with output_path.open("wb") as output_file:
             writer.write(output_file)
-        overlay_path.unlink(missing_ok=True)
         return output_path
     except ToolError:
         raise
     except Exception as exc:
         raise ToolError(f"Failed to render anonymized CV PDF: {exc}") from exc
+    finally:
+        if "overlay_path" in locals():
+            overlay_path.unlink(missing_ok=True)
+
+
+def _deduplicate_identical_overlay_pages(pages: list[object]) -> list[object]:
+    """Collapse accidental duplicate overlay pages while preserving real multipage CVs."""
+    if len(pages) <= 1:
+        return pages
+
+    fingerprints = [_page_text_fingerprint(page) for page in pages]
+    first_fingerprint = fingerprints[0]
+    if first_fingerprint and all(
+        fingerprint == first_fingerprint for fingerprint in fingerprints[1:]
+    ):
+        return [pages[0]]
+    return pages
+
+
+def _page_text_fingerprint(page: object) -> str:
+    extract_text = getattr(page, "extract_text", None)
+    if not callable(extract_text):
+        return ""
+    page_text = extract_text() or ""
+    return "\n".join(line.strip() for line in page_text.splitlines() if line.strip())
 
 
 def _write_text_overlay(

--- a/tests/unit/test_cv_export.py
+++ b/tests/unit/test_cv_export.py
@@ -131,6 +131,104 @@ def test_render_anonymized_cv_pdf_writes_output_with_template(monkeypatch: pytes
     assert not output_path.with_suffix(".overlay.pdf").exists()
 
 
+def test_render_anonymized_cv_pdf_collapses_identical_duplicate_overlay_pages(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    template_path = tmp_path / "template.pdf"
+    template_path.write_bytes(b"template")
+    output_path = tmp_path / "out.pdf"
+    captured: dict[str, int] = {"added_pages": 0, "writes": 0}
+
+    class FakePage:
+        mediabox = SimpleNamespace(width=595, height=842)
+
+        def __init__(self, text: str = "") -> None:
+            self.text = text
+
+        def extract_text(self) -> str:
+            return self.text
+
+        def merge_page(self, other: object) -> None:
+            self.other = other
+
+    class FakeReader:
+        def __init__(self, path: str) -> None:
+            if path.endswith(".overlay.pdf"):
+                self.pages = [FakePage("M. R.\nEngineer"), FakePage("M. R.\nEngineer")]
+            else:
+                self.pages = [FakePage()]
+
+    class FakeWriter:
+        def add_page(self, page: object) -> None:
+            captured["added_pages"] += 1
+
+        def write(self, file_obj: object) -> None:
+            captured["writes"] += 1
+            file_obj.write(b"%PDF fake anonymized cv")
+
+    import sys
+
+    monkeypatch.setitem(sys.modules, "pypdf", SimpleNamespace(PdfReader=FakeReader, PdfWriter=FakeWriter))
+    monkeypatch.setattr(
+        cv_pdf_rendering,
+        "_write_text_overlay",
+        lambda text, overlay_path, width, height: overlay_path.write_bytes(b"overlay"),
+    )
+
+    cv_pdf_rendering.render_anonymized_cv_pdf("M. R.\nEngineer", output_path, template_path=template_path)
+
+    assert captured["added_pages"] == 1
+    assert captured["writes"] == 1
+
+
+def test_render_anonymized_cv_pdf_preserves_distinct_overlay_pages(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    template_path = tmp_path / "template.pdf"
+    template_path.write_bytes(b"template")
+    output_path = tmp_path / "out.pdf"
+    captured: dict[str, int] = {"added_pages": 0}
+
+    class FakePage:
+        mediabox = SimpleNamespace(width=595, height=842)
+
+        def __init__(self, text: str = "") -> None:
+            self.text = text
+
+        def extract_text(self) -> str:
+            return self.text
+
+        def merge_page(self, other: object) -> None:
+            self.other = other
+
+    class FakeReader:
+        def __init__(self, path: str) -> None:
+            if path.endswith(".overlay.pdf"):
+                self.pages = [FakePage("Experience"), FakePage("Education")]
+            else:
+                self.pages = [FakePage()]
+
+    class FakeWriter:
+        def add_page(self, page: object) -> None:
+            captured["added_pages"] += 1
+
+        def write(self, file_obj: object) -> None:
+            file_obj.write(b"%PDF fake anonymized cv")
+
+    import sys
+
+    monkeypatch.setitem(sys.modules, "pypdf", SimpleNamespace(PdfReader=FakeReader, PdfWriter=FakeWriter))
+    monkeypatch.setattr(
+        cv_pdf_rendering,
+        "_write_text_overlay",
+        lambda text, overlay_path, width, height: overlay_path.write_bytes(b"overlay"),
+    )
+
+    cv_pdf_rendering.render_anonymized_cv_pdf("Experience\nEducation", output_path, template_path=template_path)
+
+    assert captured["added_pages"] == 2
+
+
 def test_anonymized_cv_endpoint_returns_pdf_and_deletes_temp_dir(monkeypatch: pytest.MonkeyPatch) -> None:
     from starlette.applications import Starlette
     from starlette.testclient import TestClient


### PR DESCRIPTION
### Motivation

- The anonymized CV was being duplicated in the final PDF because identical overlay pages generated by the text renderer were merged multiple times onto the letterhead template.
- Ensure the template is not appended multiple times and that anonymized text overlays are only merged once per logical page.

### Description

- Add `_deduplicate_identical_overlay_pages` to collapse accidental identical overlay pages by comparing a text fingerprint for each overlay page. 
- Add `_page_text_fingerprint` which uses `page.extract_text()` to build a normalized fingerprint and preserve real multipage CVs when pages differ. 
- Use the deduplicated `overlay_pages` list when merging overlays into the template and raise a `ToolError` if the generated overlay contains no pages. 
- Ensure the temporary overlay file cleanup happens in a single `finally` path and keep a single `writer.write()` call to avoid multiple writes.

### Testing

- Ran `PYTHONPATH=src python -m compileall src` which completed successfully. 
- Ran `PYTHONPATH=src pytest -q` which succeeded with `66 passed` and `1` Starlette deprecation warning. 
- Added unit tests `test_render_anonymized_cv_pdf_collapses_identical_duplicate_overlay_pages` and `test_render_anonymized_cv_pdf_preserves_distinct_overlay_pages` in `tests/unit/test_cv_export.py`, and both tests passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fb9714eb48328bb926f0a8e4d81b8)