### PR TITLE
fix: update CV anonymization prompt and output formatting

### DIFF
--- a/src/services/cv_anonymization.py
+++ b/src/services/cv_anonymization.py
@@ -4,21 +4,36 @@ from fastmcp.exceptions import ToolError
 
 from clients.ollama import chat_with_ollama
 
-CV_ANONYMIZATION_PROMPT_TEMPLATE = """You anonymize CV content for PDF export.
+CV_ANONYMIZATION_PROMPT_TEMPLATE = """You anonymize and format CV content for PDF export.
 
 Privacy rules:
+- Keep the candidate name.
 - Remove phone numbers.
 - Remove email addresses.
-- Remove street names and house numbers.
-- Remove the candidate's first name and surname entirely; do not replace names with initials or placeholders.
+- Remove street addresses.
+- Remove street names.
+- Remove house numbers.
+- Remove postal codes.
 - Keep only the city from any address, for example "Via Roma 10, 6900 Lugano, Switzerland" becomes "Lugano".
-- Preserve professional experience, education, skills, certifications, languages, projects, technical competencies, and professional summary.
-- Remove or transform only personally identifiable information.
+- Preserve professional experience, education, skills, certifications, languages, projects, technical competencies, hobbies, and professional summary when present.
+- Remove or transform only personally identifiable information other than the candidate name.
+
+Formatting rules:
+- Return the anonymized CV using exactly these sections and this order:
+  1. Anagraphical data
+  2. Experience
+  3. Education
+  4. Skills
+  5. Certifications
+  6. Hobby
+- Section titles must be bold, for example **Anagraphical data**.
+- Use round bullet points for lists.
+- If a section has no supported content in the CV, include the bold section title and write a round bullet point with "Not specified".
 
 Output rules:
-- Return only the anonymized CV content.
+- Return only the formatted anonymized CV content.
 - Do not start with an introductory sentence such as "Here is the anonymized CV content for PDF export:".
-- Do not add commentary, explanations, notes, markdown, or extra text.
+- Do not add introductions, explanations, comments, notes, markdown fences, or extra text.
 
 CV content:
 {cv_text}

--- a/tests/unit/test_cv_export.py
+++ b/tests/unit/test_cv_export.py
@@ -49,18 +49,45 @@ def test_anonymize_cv_text_uses_ollama_prompt(monkeypatch: pytest.MonkeyPatch) -
 
     async def fake_chat_with_ollama(prompt: str, **_: object) -> str:
         captured["prompt"] = prompt
-        return "Lugano\nSenior Developer"
+        return (
+            "**Anagraphical data**\n"
+            "• Gabriele Di Somma\n"
+            "• Lugano\n"
+            "**Experience**\n"
+            "• Senior Developer"
+        )
 
     monkeypatch.setattr(cv_anonymization, "chat_with_ollama", fake_chat_with_ollama)
 
-    result = asyncio.run(cv_anonymization.anonymize_cv_text("Gabriele Di Somma\ngabriele@example.com\nVia Roma 10, Lugano"))
+    result = asyncio.run(
+        cv_anonymization.anonymize_cv_text(
+            "Gabriele Di Somma\ngabriele@example.com\nVia Roma 10, Lugano"
+        )
+    )
 
-    assert result == "Lugano\nSenior Developer"
+    assert result == (
+        "**Anagraphical data**\n"
+        "• Gabriele Di Somma\n"
+        "• Lugano\n"
+        "**Experience**\n"
+        "• Senior Developer"
+    )
+    assert "Keep the candidate name" in captured["prompt"]
     assert "Remove phone numbers" in captured["prompt"]
     assert "Remove email addresses" in captured["prompt"]
-    assert "Remove the candidate's first name and surname entirely" in captured["prompt"]
-    assert "do not replace names with initials or placeholders" in captured["prompt"]
-    assert "Return only the anonymized CV content" in captured["prompt"]
+    assert "Remove street addresses" in captured["prompt"]
+    assert "Remove house numbers" in captured["prompt"]
+    assert "Remove postal codes" in captured["prompt"]
+    assert "Keep only the city" in captured["prompt"]
+    assert "Anagraphical data" in captured["prompt"]
+    assert "Experience" in captured["prompt"]
+    assert "Education" in captured["prompt"]
+    assert "Skills" in captured["prompt"]
+    assert "Certifications" in captured["prompt"]
+    assert "Hobby" in captured["prompt"]
+    assert "Section titles must be bold" in captured["prompt"]
+    assert "Use round bullet points" in captured["prompt"]
+    assert "Return only the formatted anonymized CV content" in captured["prompt"]
     assert "Do not start with an introductory sentence" in captured["prompt"]
 
 


### PR DESCRIPTION
### Motivation
- Align the Ollama anonymization prompt with new export requirements to preserve the candidate name while continuing to redact other PII.
- Enforce a strict, reproducible anonymized CV structure and formatting for PDF export to make downstream rendering and review predictable.
- Make the prompt explicit about exact section order, bold section titles, and round bullet points so model output is machine- and human-friendly.

### Description
- Updated `CV_ANONYMIZATION_PROMPT_TEMPLATE` in `src/services/cv_anonymization.py` to keep the candidate name, continue removing phone/email/street/house/postal data, and keep only the city for addresses.
- Added formatting rules to the prompt that require the anonymized CV to use exactly these sections in order: `Anagraphical data`, `Experience`, `Education`, `Skills`, `Certifications`, `Hobby`, with bold section titles and round bullet points, and `"Not specified"` when a section is empty.
- Adjusted the anonymization output rule to return only the formatted anonymized CV content and disallow extra commentary or introductory sentences.
- Updated `tests/unit/test_cv_export.py` to assert the new prompt contents and to validate a sample formatted anonymized CV response.

### Testing
- Ran `python -m compileall src`, which completed successfully.
- Ran `PYTHONPATH=src pytest`, which completed successfully with `66 passed, 1 warning` (existing Starlette deprecation warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fcc124fb083288c39026e9d8612f9)