### PR TITLE
fix: correct anonymized CV PDF formatting

### DIFF
--- a/src/services/cv_anonymization.py
+++ b/src/services/cv_anonymization.py
@@ -7,7 +7,7 @@ from clients.ollama import chat_with_ollama
 CV_ANONYMIZATION_PROMPT_TEMPLATE = """You anonymize and format CV content for PDF export.
 
 Privacy rules:
-- Keep the candidate name.
+- Keep only the candidate first/given name; remove surnames/family names.
 - Remove phone numbers.
 - Remove email addresses.
 - Remove street addresses.
@@ -16,7 +16,7 @@ Privacy rules:
 - Remove postal codes.
 - Keep only the city from any address, for example "Via Roma 10, 6900 Lugano, Switzerland" becomes "Lugano".
 - Preserve professional experience, education, skills, certifications, languages, projects, technical competencies, hobbies, and professional summary when present.
-- Remove or transform only personally identifiable information other than the candidate name.
+- Remove or transform all personally identifiable information other than the candidate first/given name.
 
 Formatting rules:
 - Return the anonymized CV using exactly these sections and this order:
@@ -26,7 +26,7 @@ Formatting rules:
   4. Skills
   5. Certifications
   6. Hobby
-- Section titles must be bold, for example **Anagraphical data**.
+- Section titles must be bold in the exported PDF. Mark each section title with markdown bold delimiters, for example **Anagraphical data**, so the renderer can draw real bold text without showing the delimiters.
 - Use round bullet points for lists.
 - If a section has no supported content in the CV, include the bold section title and write a round bullet point with "Not specified".
 

--- a/src/services/cv_pdf_rendering.py
+++ b/src/services/cv_pdf_rendering.py
@@ -45,10 +45,10 @@ def render_anonymized_cv_pdf(
         overlay_pages = list(overlay_reader.pages)
         generated_content_page_count = len(overlay_pages)
         logger.debug("CV PDF generated content page count: %s", generated_content_page_count)
-        output_pages = _remove_consecutive_duplicate_pdf_pages(overlay_pages)
+        output_pages = _remove_duplicate_pdf_pages(overlay_pages)
         if len(output_pages) != generated_content_page_count:
             logger.debug(
-                "CV PDF removed %s consecutive duplicate generated content page(s).",
+                "CV PDF removed %s duplicate generated content page(s).",
                 generated_content_page_count - len(output_pages),
             )
         if not output_pages:
@@ -77,19 +77,19 @@ def render_anonymized_cv_pdf(
             overlay_path.unlink(missing_ok=True)
 
 
-def _remove_consecutive_duplicate_pdf_pages(pages: list[object]) -> list[object]:
-    """Remove consecutive duplicate generated pages from the PDF pipeline."""
-    if len(pages) <= 1:
-        return pages
+def _remove_duplicate_pdf_pages(pages: list[object]) -> list[object]:
+    """Remove generated pages that contain exactly the same information."""
+    unique_pages: list[object] = []
+    seen_fingerprints: set[str] = set()
 
-    unique_pages = [pages[0]]
-    previous_fingerprint = _pdf_page_fingerprint(pages[0])
-    for page in pages[1:]:
+    for page in pages:
         fingerprint = _pdf_page_fingerprint(page)
-        if fingerprint and fingerprint == previous_fingerprint:
+        if fingerprint and fingerprint in seen_fingerprints:
             continue
         unique_pages.append(page)
-        previous_fingerprint = fingerprint
+        if fingerprint:
+            seen_fingerprints.add(fingerprint)
+
     return unique_pages
 
 
@@ -129,6 +129,7 @@ def _write_text_overlay(
     top_margin = 42 * mm
     bottom_margin = 22 * mm
     font_name = "Helvetica"
+    bold_font_name = "Helvetica-Bold"
     font_size = 10
     line_height = 14
     chars_per_line = max(
@@ -147,6 +148,15 @@ def _write_text_overlay(
                 pdf.setFillColor(HexColor("#222222"))
                 pdf.setFont(font_name, font_size)
                 y = page_height - top_margin
-            pdf.drawString(left_margin, y, line)
+            line_font_name, drawable_line = _pdf_line_style(line, font_name, bold_font_name)
+            pdf.setFont(line_font_name, font_size)
+            pdf.drawString(left_margin, y, drawable_line)
             y -= line_height
     pdf.save()
+
+
+def _pdf_line_style(line: str, font_name: str, bold_font_name: str) -> tuple[str, str]:
+    stripped_line = line.strip()
+    if stripped_line.startswith("**") and stripped_line.endswith("**") and len(stripped_line) > 4:
+        return bold_font_name, stripped_line.removeprefix("**").removesuffix("**")
+    return font_name, line

--- a/tests/unit/test_cv_export.py
+++ b/tests/unit/test_cv_export.py
@@ -72,7 +72,7 @@ def test_anonymize_cv_text_uses_ollama_prompt(monkeypatch: pytest.MonkeyPatch) -
         "**Experience**\n"
         "• Senior Developer"
     )
-    assert "Keep the candidate name" in captured["prompt"]
+    assert "Keep only the candidate first/given name" in captured["prompt"]
     assert "Remove phone numbers" in captured["prompt"]
     assert "Remove email addresses" in captured["prompt"]
     assert "Remove street addresses" in captured["prompt"]
@@ -85,7 +85,7 @@ def test_anonymize_cv_text_uses_ollama_prompt(monkeypatch: pytest.MonkeyPatch) -
     assert "Skills" in captured["prompt"]
     assert "Certifications" in captured["prompt"]
     assert "Hobby" in captured["prompt"]
-    assert "Section titles must be bold" in captured["prompt"]
+    assert "Section titles must be bold in the exported PDF" in captured["prompt"]
     assert "Use round bullet points" in captured["prompt"]
     assert "Return only the formatted anonymized CV content" in captured["prompt"]
     assert "Do not start with an introductory sentence" in captured["prompt"]
@@ -208,6 +208,54 @@ def test_render_anonymized_cv_pdf_collapses_identical_duplicate_overlay_pages(
     assert captured["writes"] == 1
 
 
+def test_render_anonymized_cv_pdf_collapses_nonconsecutive_duplicate_overlay_pages(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    template_path = tmp_path / "template.pdf"
+    template_path.write_bytes(b"template")
+    output_path = tmp_path / "out.pdf"
+    captured: dict[str, int] = {"added_pages": 0}
+
+    class FakePage:
+        mediabox = SimpleNamespace(width=595, height=842)
+
+        def __init__(self, text: str = "") -> None:
+            self.text = text
+
+        def extract_text(self) -> str:
+            return self.text
+
+        def merge_page(self, other: object) -> None:
+            self.other = other
+
+    class FakeReader:
+        def __init__(self, path: str) -> None:
+            if path.endswith(".overlay.pdf"):
+                self.pages = [FakePage("Experience"), FakePage("Education"), FakePage("Experience")]
+            else:
+                self.pages = [FakePage()]
+
+    class FakeWriter:
+        def add_page(self, page: object) -> None:
+            captured["added_pages"] += 1
+
+        def write(self, file_obj: object) -> None:
+            file_obj.write(b"%PDF fake anonymized cv")
+
+    import sys
+
+    monkeypatch.setitem(sys.modules, "pypdf", SimpleNamespace(PdfReader=FakeReader, PdfWriter=FakeWriter))
+    monkeypatch.setattr(
+        cv_pdf_rendering,
+        "_write_text_overlay",
+        lambda text, overlay_path, width, height: overlay_path.write_bytes(b"overlay"),
+    )
+
+    cv_pdf_rendering.render_anonymized_cv_pdf("Experience\nEducation", output_path, template_path=template_path)
+
+    assert captured["added_pages"] == 2
+
+
 def test_render_anonymized_cv_pdf_preserves_distinct_overlay_pages(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -254,6 +302,13 @@ def test_render_anonymized_cv_pdf_preserves_distinct_overlay_pages(
     cv_pdf_rendering.render_anonymized_cv_pdf("Experience\nEducation", output_path, template_path=template_path)
 
     assert captured["added_pages"] == 2
+
+
+def test_pdf_line_style_renders_markdown_heading_as_real_bold_text() -> None:
+    font_name, line = cv_pdf_rendering._pdf_line_style("**Experience**", "Helvetica", "Helvetica-Bold")
+
+    assert font_name == "Helvetica-Bold"
+    assert line == "Experience"
 
 
 def test_anonymized_cv_endpoint_returns_pdf_and_deletes_temp_dir(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
### Motivation
- Remove duplicated PDF pages that contain the same information so exported CVs do not include redundant pages.
- Enforce the privacy requirement to keep only the candidate first/given name and remove surnames/family names.
- Ensure section titles are rendered as real bold text in the PDF rather than showing markdown `**` delimiters.

### Description
- Updated the anonymization prompt in `src/services/cv_anonymization.py` to require keeping only the candidate first/given name and to clarify section-title formatting for the renderer.
- Replaced the consecutive-only duplicate removal with a fingerprint-based deduplication in `src/services/cv_pdf_rendering.py` by adding `_remove_duplicate_pdf_pages` that filters duplicate pages anywhere in the overlay.
- Implemented `_pdf_line_style` and used a `Helvetica-Bold` font in `_write_text_overlay` so lines wrapped as `**Section**` are drawn with a bold font and the visible `**` markers are removed at render time.
- Added unit tests and adjusted expectations in `tests/unit/test_cv_export.py` to cover non-consecutive duplicate page collapsing and the markdown-heading-to-bold rendering, and to reflect the updated prompt wording.

### Testing
- Ran `PYTHONPATH=src python -m compileall src` successfully.
- Ran `PYTHONPATH=src pytest` and all tests passed: `68 passed`, with `1` existing Starlette deprecation warning.  All new and updated unit tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fd76e9d1c832880a8cafe52dc11c1)