### PR TITLE
fix: render CV pages without duplicated content

### DIFF
--- a/src/services/cv_pdf_rendering.py
+++ b/src/services/cv_pdf_rendering.py
@@ -132,6 +132,7 @@ def _write_text_overlay(
     bold_font_name = "Helvetica-Bold"
     font_size = 10
     line_height = 14
+    section_gap = 8
     chars_per_line = max(
         40, int((page_width - left_margin - right_margin) / (font_size * 0.52))
     )
@@ -140,19 +141,64 @@ def _write_text_overlay(
     pdf.setFillColor(HexColor("#222222"))
     pdf.setFont(font_name, font_size)
 
-    for paragraph in text.splitlines():
-        wrapped_lines = textwrap.wrap(paragraph, width=chars_per_line) if paragraph.strip() else [""]
+    for flow_line in _build_cv_flow_lines(text):
+        wrapped_lines = textwrap.wrap(flow_line.text, width=chars_per_line) or [flow_line.text]
+        required_height = len(wrapped_lines) * line_height
+        if flow_line.starts_section:
+            required_height += section_gap
+        if y - required_height < bottom_margin:
+            pdf.showPage()
+            pdf.setFillColor(HexColor("#222222"))
+            pdf.setFont(font_name, font_size)
+            y = page_height - top_margin
+        elif flow_line.starts_section:
+            y -= section_gap
+
         for line in wrapped_lines:
-            if y <= bottom_margin:
-                pdf.showPage()
-                pdf.setFillColor(HexColor("#222222"))
-                pdf.setFont(font_name, font_size)
-                y = page_height - top_margin
             line_font_name, drawable_line = _pdf_line_style(line, font_name, bold_font_name)
             pdf.setFont(line_font_name, font_size)
             pdf.drawString(left_margin, y, drawable_line)
             y -= line_height
     pdf.save()
+
+
+class _CvFlowLine:
+    def __init__(self, text: str, starts_section: bool = False) -> None:
+        self.text = text
+        self.starts_section = starts_section
+
+
+def _build_cv_flow_lines(text: str) -> list[_CvFlowLine]:
+    """Build drawable CV lines with spacing only before distinct sections."""
+    flow_lines: list[_CvFlowLine] = []
+    previous_was_section = False
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        is_section = _is_section_heading(line)
+        starts_section = bool(flow_lines) and is_section and not previous_was_section
+        flow_lines.append(_CvFlowLine(line, starts_section=starts_section))
+        previous_was_section = is_section
+
+    return flow_lines
+
+
+def _is_section_heading(line: str) -> bool:
+    stripped_line = line.strip()
+    if stripped_line.startswith("**") and stripped_line.endswith("**") and len(stripped_line) > 4:
+        return True
+    normalized = stripped_line.rstrip(":").lower()
+    return normalized in {
+        "anagraphical data",
+        "experience",
+        "education",
+        "skills",
+        "certifications",
+        "hobby",
+    }
 
 
 def _pdf_line_style(line: str, font_name: str, bold_font_name: str) -> tuple[str, str]:

--- a/tests/unit/test_cv_export.py
+++ b/tests/unit/test_cv_export.py
@@ -350,3 +350,109 @@ def test_anonymized_cv_endpoint_returns_pdf_and_deletes_temp_dir(monkeypatch: py
     assert captured["text"] == "Raw CV"
     assert captured["anonymized"] == "Anonymized CV"
     assert not captured["temp_dir"].exists()
+
+
+def test_cv_flow_lines_add_spacing_only_between_sections() -> None:
+    text = (
+        "**Experience**\n"
+        "\n"
+        "• Senior Developer\n"
+        "\n"
+        "• Platform Engineer\n"
+        "\n"
+        "**Skills**\n"
+        "\n"
+        "• Python\n"
+        "• FastMCP\n"
+        "\n"
+        "**Certifications**\n"
+        "• Cloud Practitioner — 2024 — Provider\n"
+        "• Built secure services"
+    )
+
+    flow_lines = cv_pdf_rendering._build_cv_flow_lines(text)
+
+    assert [line.text for line in flow_lines] == [
+        "**Experience**",
+        "• Senior Developer",
+        "• Platform Engineer",
+        "**Skills**",
+        "• Python",
+        "• FastMCP",
+        "**Certifications**",
+        "• Cloud Practitioner — 2024 — Provider",
+        "• Built secure services",
+    ]
+    assert [line.starts_section for line in flow_lines] == [
+        False,
+        False,
+        False,
+        True,
+        False,
+        False,
+        True,
+        False,
+        False,
+    ]
+
+
+def test_write_text_overlay_single_page_does_not_duplicate_content(tmp_path: Path) -> None:
+    from pypdf import PdfReader
+
+    overlay_path = tmp_path / "single-page-overlay.pdf"
+    text = (
+        "**Anagraphical data**\n"
+        "• Candidate\n"
+        "**Experience**\n"
+        "• Developer\n"
+        "**Education**\n"
+        "• University\n"
+        "**Skills**\n"
+        "• Python\n"
+        "• PDF rendering\n"
+        "**Certifications**\n"
+        "• Cloud Practitioner — 2024 — Example Provider\n"
+        "• Validated cloud fundamentals\n"
+        "**Hobby**\n"
+        "• Reading"
+    )
+
+    cv_pdf_rendering._write_text_overlay(text, overlay_path, 595, 842)
+
+    reader = PdfReader(str(overlay_path))
+    extracted_pages = [page.extract_text() for page in reader.pages]
+    full_text = "\n".join(extracted_pages)
+    assert len(extracted_pages) == 1
+    assert full_text.count("Skills") == 1
+    assert full_text.count("Certifications") == 1
+    assert full_text.index("Skills") < full_text.index("Certifications")
+    assert full_text.count("Cloud Practitioner") == 1
+
+
+def test_write_text_overlay_multipage_continues_instead_of_repeating_page_one(tmp_path: Path) -> None:
+    from pypdf import PdfReader
+
+    overlay_path = tmp_path / "multipage-overlay.pdf"
+    experience_items = "\n".join(f"• Experience item {index}" for index in range(1, 80))
+    text = (
+        "**Experience**\n"
+        f"{experience_items}\n"
+        "**Skills**\n"
+        "• Python\n"
+        "**Certifications**\n"
+        "• Cloud Practitioner — 2024 — Example Provider\n"
+        "• Validated cloud fundamentals"
+    )
+
+    cv_pdf_rendering._write_text_overlay(text, overlay_path, 595, 842)
+
+    reader = PdfReader(str(overlay_path))
+    extracted_pages = [page.extract_text() for page in reader.pages]
+    assert len(extracted_pages) > 1
+    assert extracted_pages[0] != extracted_pages[1]
+    combined_text = "\n".join(extracted_pages)
+    assert combined_text.splitlines().count("Experience") == 1
+    assert combined_text.count("Experience item 79") == 1
+    assert combined_text.count("Skills") == 1
+    assert combined_text.count("Certifications") == 1
+    assert combined_text.index("Skills") < combined_text.index("Certifications")


### PR DESCRIPTION
### Motivation
- Anonymized CV exports were duplicating page content across output pages instead of continuing content when pagination was required. 
- Vertical spacing was applied inconsistently, producing extra blank lines inside sections and duplicated gaps between items. 
- The `Skills` and `Certifications` sections were not consistently treated as first-class sections in the normal flow, which caused ordering/duplication issues.

### Description
- Render flow normalization: added `_build_cv_flow_lines` and `_is_section_heading` to normalize input lines, drop empty input lines, and mark section-starts so spacing is applied only between sections (`src/services/cv_pdf_rendering.py`).
- Pagination fix: updated `_write_text_overlay` to iterate the normalized flow, compute required heights per logical block, and create new pages when needed so each logical page is rendered exactly once (`src/services/cv_pdf_rendering.py`).
- Section spacing: introduced a `section_gap` and apply it only when a new section begins to avoid duplicated or intra-section blank lines (`src/services/cv_pdf_rendering.py`).
- Tests: added regression tests that verify one-page output, multi-page continuation (no repetition of page 1), correct ordering and single rendering of `Skills` and `Certifications`, and section-only spacing (`tests/unit/test_cv_export.py`).

### Testing
- Ran `python -m compileall src` which completed successfully. 
- Ran the full test suite with `PYTHONPATH=src pytest -q` and all tests passed (71 passed, 1 existing Starlette deprecation warning). 
- Executed focused regression tests in `tests/unit/test_cv_export.py` (new tests included) which assert no duplicated pages, correct `Skills`/`Certifications` rendering, and spacing behavior; these tests passed under the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30f974d37c8328ae0f1cf775bd1c95)