### PR TITLE
fix: render CV enumerations with round bullets

### DIFF
--- a/src/services/cv_anonymization.py
+++ b/src/services/cv_anonymization.py
@@ -27,7 +27,7 @@ Formatting rules:
   5. Certifications
   6. Hobby
 - Section titles must be bold in the exported PDF. Mark each section title with markdown bold delimiters, for example **Anagraphical data**, so the renderer can draw real bold text without showing the delimiters.
-- Use round bullet points for lists.
+- Use only round bullet points for lists; never use square bullet points.
 - If a section has no supported content in the CV, include the bold section title and write a round bullet point with "Not specified".
 
 Output rules:

--- a/src/services/cv_pdf_rendering.py
+++ b/src/services/cv_pdf_rendering.py
@@ -12,6 +12,9 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_TEMPLATE_PATH = REPOSITORY_ROOT / "stationery" / "relewant-sa-letterhead.pdf"
 logger = logging.getLogger(__name__)
 
+ROUND_BULLET = "•"
+SQUARE_BULLETS = frozenset({"▪", "■", "□", "▫", "◾", "◼", "◻", "▣", "▢"})
+
 
 def render_anonymized_cv_pdf(
     anonymized_text: str,
@@ -141,8 +144,13 @@ def _write_text_overlay(
     pdf.setFillColor(HexColor("#222222"))
     pdf.setFont(font_name, font_size)
 
+    bullet_gap = 4
+    bullet_radius = 1.7
+
     for flow_line in _build_cv_flow_lines(text):
-        wrapped_lines = textwrap.wrap(flow_line.text, width=chars_per_line) or [flow_line.text]
+        bullet_text = _round_bullet_text(flow_line.text)
+        drawable_text = bullet_text or flow_line.text
+        wrapped_lines = textwrap.wrap(drawable_text, width=chars_per_line) or [drawable_text]
         required_height = len(wrapped_lines) * line_height
         if flow_line.starts_section:
             required_height += section_gap
@@ -154,10 +162,22 @@ def _write_text_overlay(
         elif flow_line.starts_section:
             y -= section_gap
 
-        for line in wrapped_lines:
+        for line_index, line in enumerate(wrapped_lines):
             line_font_name, drawable_line = _pdf_line_style(line, font_name, bold_font_name)
             pdf.setFont(line_font_name, font_size)
-            pdf.drawString(left_margin, y, drawable_line)
+            if bullet_text is not None:
+                text_x = left_margin + bullet_radius * 2 + bullet_gap
+                if line_index == 0:
+                    pdf.circle(
+                        left_margin + bullet_radius,
+                        y + (font_size * 0.35),
+                        bullet_radius,
+                        stroke=0,
+                        fill=1,
+                    )
+                pdf.drawString(text_x, y, drawable_line)
+            else:
+                pdf.drawString(left_margin, y, drawable_line)
             y -= line_height
     pdf.save()
 
@@ -178,6 +198,7 @@ def _build_cv_flow_lines(text: str) -> list[_CvFlowLine]:
         if not line:
             continue
 
+        line = _normalize_bullet_prefix(line)
         is_section = _is_section_heading(line)
         starts_section = bool(flow_lines) and is_section and not previous_was_section
         flow_lines.append(_CvFlowLine(line, starts_section=starts_section))
@@ -206,3 +227,20 @@ def _pdf_line_style(line: str, font_name: str, bold_font_name: str) -> tuple[str
     if stripped_line.startswith("**") and stripped_line.endswith("**") and len(stripped_line) > 4:
         return bold_font_name, stripped_line.removeprefix("**").removesuffix("**")
     return font_name, line
+
+
+def _normalize_bullet_prefix(line: str) -> str:
+    stripped_line = line.lstrip()
+    if not stripped_line:
+        return line
+    if stripped_line[0] in SQUARE_BULLETS:
+        leading_whitespace = line[: len(line) - len(stripped_line)]
+        return f"{leading_whitespace}{ROUND_BULLET}{stripped_line[1:]}"
+    return line
+
+
+def _round_bullet_text(line: str) -> str | None:
+    stripped_line = line.lstrip()
+    if not stripped_line or stripped_line[0] != ROUND_BULLET:
+        return None
+    return stripped_line[1:].strip()

--- a/tests/unit/test_cv_export.py
+++ b/tests/unit/test_cv_export.py
@@ -86,7 +86,8 @@ def test_anonymize_cv_text_uses_ollama_prompt(monkeypatch: pytest.MonkeyPatch) -
     assert "Certifications" in captured["prompt"]
     assert "Hobby" in captured["prompt"]
     assert "Section titles must be bold in the exported PDF" in captured["prompt"]
-    assert "Use round bullet points" in captured["prompt"]
+    assert "Use only round bullet points" in captured["prompt"]
+    assert "never use square bullet points" in captured["prompt"]
     assert "Return only the formatted anonymized CV content" in captured["prompt"]
     assert "Do not start with an introductory sentence" in captured["prompt"]
 
@@ -394,6 +395,30 @@ def test_cv_flow_lines_add_spacing_only_between_sections() -> None:
         False,
         False,
     ]
+
+
+def test_cv_flow_lines_normalize_square_bullets_to_round_bullets() -> None:
+    text = (
+        "**Experience**\n"
+        "▪ Senior Developer\n"
+        "■ Platform Engineer\n"
+        "□ Team Lead"
+    )
+
+    flow_lines = cv_pdf_rendering._build_cv_flow_lines(text)
+
+    assert [line.text for line in flow_lines] == [
+        "**Experience**",
+        "• Senior Developer",
+        "• Platform Engineer",
+        "• Team Lead",
+    ]
+
+
+def test_round_bullet_text_detects_only_round_bullet_prefixes() -> None:
+    assert cv_pdf_rendering._round_bullet_text("• Senior Developer") == "Senior Developer"
+    assert cv_pdf_rendering._round_bullet_text("  • Lugano") == "Lugano"
+    assert cv_pdf_rendering._round_bullet_text("Experience") is None
 
 
 def test_write_text_overlay_single_page_does_not_duplicate_content(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- CV exports sometimes rendered square glyphs for enumeration markers instead of round bullets, breaking the intended visual style.
- The renderer and anonymization prompt must enforce and produce round bullets only to ensure consistent PDF output.

### Description
- Tightened the CV anonymization prompt to require `only round bullet points` and explicitly forbid square bullet characters.
- Added `SQUARE_BULLETS` and `ROUND_BULLET` constants and a `_normalize_bullet_prefix` helper to convert square bullet prefixes into round bullets before layout.
- Changed the PDF overlay rendering in `_write_text_overlay` to draw bullets as filled round circles (using `canvas.circle`) and lay out text with an indented text column when bullets are present.
- Added unit tests `test_cv_flow_lines_normalize_square_bullets_to_round_bullets` and `test_round_bullet_text_detects_only_round_bullet_prefixes` in `tests/unit/test_cv_export.py` to cover normalization and detection logic.

### Testing
- Ran `python -m compileall src`, which completed successfully.
- Ran `PYTHONPATH=src pytest tests/unit/test_cv_export.py -k 'not write_text_overlay'`, which ran 15 tests and all passed.
- Ran `PYTHONPATH=src pytest tests/unit/test_cv_export.py` which exercised the full test module but encountered two failing overlay tests because the `pypdf` dependency is not installed in the environment; 15 tests passed and 2 tests failed due to the missing `pypdf` runtime dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3105974d7883289b74e5750bbecb4b)