### PR TITLE
fix: preserve candidate education in qdrant payloads

### DIFF
--- a/src/http_api.py
+++ b/src/http_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from importlib.util import find_spec
 from typing import Any, Iterable
 
@@ -67,6 +68,8 @@ else:
     from routers.cv_export import router as cv_export_router
     from routers.document import router as document_router
     from routers.prompt import router as prompt_router
+    from logging_config import get_logger
+    from services.document_persistence import ensure_qdrant_collections
     from services.document_upload import PdfUploadResponse
     from services.prompt_router import PromptExecutionRequest, PromptExecutionResponse
 
@@ -258,9 +261,18 @@ else:
             }
         )
 
+    logger = get_logger()
+
+    @asynccontextmanager
+    async def lifespan(_: Starlette):
+        await ensure_qdrant_collections()
+        logger.info("Qdrant collections initialized for PDF processing")
+        yield
+
     def create_app() -> Starlette:
         return Starlette(
             debug=False,
+            lifespan=lifespan,
             routes=[
                 Route("/", api_hint, methods=["GET"]),
                 Route("/docs", swagger_docs, methods=["GET"]),

--- a/src/services/document_persistence.py
+++ b/src/services/document_persistence.py
@@ -12,6 +12,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
 from clients.ollama import chat_with_ollama
+from logging_config import get_logger
 from services.performance import log_performance_event
 from config import (
     QDRANT_CANDIDATES_COLLECTION,
@@ -22,6 +23,9 @@ from config import (
 
 
 VECTOR_DB_CHUNK_SIZE = 4000
+QDRANT_DUMMY_VECTOR_SIZE = 1
+QDRANT_DUMMY_VECTOR = [1.0]
+logger = get_logger()
 DocumentDomain = Literal["cv", "insurance", "other"]
 MetadataKind = Literal["candidate", "insurance"]
 
@@ -340,8 +344,11 @@ def build_vector_db_records(
     *,
     metadata_kind: str | None = None,
 ) -> list[VectorDbRecord]:
-    metadata = build_vector_db_metadata(
+    normalized_payload = _normalize_metadata_aliases(
         extracted_payload, metadata_kind=metadata_kind
+    )
+    metadata = build_vector_db_metadata(
+        normalized_payload, metadata_kind=metadata_kind
     )
     embedding_text = _embedding_text_from_payload(metadata)
     chunks = (
@@ -366,9 +373,12 @@ def build_vector_db_metadata(
     *,
     metadata_kind: str | None = None,
 ) -> dict[str, Any]:
+    normalized_payload = _normalize_metadata_aliases(
+        extracted_payload, metadata_kind=metadata_kind
+    )
     schema = _metadata_schema(metadata_kind)
     try:
-        metadata_model = schema.model_validate(extracted_payload)
+        metadata_model = schema.model_validate(normalized_payload)
     except ValidationError as exc:
         raise VectorDbMetadataError(str(exc)) from exc
 
@@ -543,10 +553,46 @@ def _metadata_kind_for_collection(collection_name: str) -> str | None:
     return None
 
 
+async def ensure_qdrant_collections() -> None:
+    """Create required Qdrant collections for dummy-vector payload storage."""
+    for collection_name in (QDRANT_CANDIDATES_COLLECTION, QDRANT_INSURANCES_COLLECTION):
+        await _ensure_qdrant_collection(collection_name)
+
+
+async def _ensure_qdrant_collection(collection_name: str) -> None:
+    body = {
+        "vectors": {
+            "size": QDRANT_DUMMY_VECTOR_SIZE,
+            "distance": "Cosine",
+        }
+    }
+    timeout = httpx.Timeout(QDRANT_TIMEOUT_SECONDS)
+    async with httpx.AsyncClient(base_url=QDRANT_URL, timeout=timeout) as client:
+        existing_response = await client.get(f"/collections/{collection_name}")
+        if existing_response.status_code == 200:
+            return
+        if existing_response.status_code != 404:
+            try:
+                existing_response.raise_for_status()
+            except httpx.HTTPStatusError as exc:
+                raise ToolError(
+                    f"Failed to inspect Qdrant collection '{collection_name}'."
+                ) from exc
+
+        response = await client.put(f"/collections/{collection_name}", json=body)
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise ToolError(
+                f"Failed to initialize Qdrant collection '{collection_name}'."
+            ) from exc
+
+
 async def _upsert_records(
     collection_name: str, records: list[VectorDbRecord]
 ) -> None:
     body = {"points": [record.model_dump(mode="json") for record in records]}
+    _log_qdrant_upsert(collection_name, records)
     timeout = httpx.Timeout(QDRANT_TIMEOUT_SECONDS)
     async with httpx.AsyncClient(base_url=QDRANT_URL, timeout=timeout) as client:
         response = await client.put(
@@ -616,8 +662,41 @@ def _metadata_for_chunk(
     return chunk_metadata
 
 
+def _normalize_metadata_aliases(
+    payload: dict[str, Any], *, metadata_kind: str | None
+) -> dict[str, Any]:
+    if metadata_kind != "candidate":
+        return payload
+
+    normalized = dict(payload)
+    if not normalized.get("education"):
+        for alias in ("educations", "education_history", "studies"):
+            alias_value = normalized.get(alias)
+            if alias_value:
+                normalized["education"] = alias_value
+                break
+    return normalized
+
+
+def _log_qdrant_upsert(collection_name: str, records: list[VectorDbRecord]) -> None:
+    for record in records:
+        logger.info(
+            "Qdrant upsert prepared collection=%s vector_length=%s structured_candidate=%s payload=%s",
+            collection_name,
+            len(record.vector),
+            _safe_log_json(record.payload)
+            if collection_name == QDRANT_CANDIDATES_COLLECTION
+            else None,
+            _safe_log_json(record.payload),
+        )
+
+
+def _safe_log_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+
+
 def _embedding_vector_for_text(_text: str) -> list[float]:
-    return [0.0]
+    return list(QDRANT_DUMMY_VECTOR)
 
 
 def _validate_metadata_values(metadata: dict[str, Any]) -> None:

--- a/tests/unit/test_document_persistence.py
+++ b/tests/unit/test_document_persistence.py
@@ -568,3 +568,128 @@ def test_build_vector_records_keeps_multipage_insurance_pdf_in_one_record(
     assert len(records) == 1
     assert records[0].payload["policy_number"] == "MULTI-1"
     assert "chunk_index" not in records[0].payload
+
+
+def test_candidate_education_alias_is_preserved_in_qdrant_payload() -> None:
+    records = build_vector_db_records(
+        {
+            "id": "candidate-alias-1",
+            "first_name": "Maria",
+            "education_history": [
+                {
+                    "degree": "MSc Computer Science",
+                    "institution": "University of Example",
+                }
+            ],
+            "raw_text": "Education: MSc Computer Science, University of Example",
+        },
+        metadata_kind="candidate",
+    )
+
+    assert records[0].payload["education"] == [
+        {
+            "degree": "MSc Computer Science",
+            "institution": "University of Example",
+        }
+    ]
+    assert records[0].vector == [1.0]
+    assert len(records[0].vector) == document_persistence.QDRANT_DUMMY_VECTOR_SIZE
+
+
+def test_persist_candidate_payload_logs_payload_vector_and_collection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logged: list[tuple[str, tuple[object, ...]]] = []
+
+    class FakeResponse:
+        status_code = 200
+
+        def raise_for_status(self) -> None:
+            return None
+
+    class FakeClient:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        async def __aenter__(self) -> "FakeClient":
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def put(self, path: str, **kwargs: object) -> FakeResponse:
+            logged.append((path, (kwargs,)))
+            return FakeResponse()
+
+    monkeypatch.setattr(document_persistence.httpx, "AsyncClient", FakeClient)
+    monkeypatch.setattr(
+        document_persistence.logger,
+        "info",
+        lambda message, *args: logged.append((message, args)),
+    )
+
+    asyncio.run(
+        persist_extracted_payload(
+            document_persistence.QDRANT_CANDIDATES_COLLECTION,
+            {
+                "id": "candidate-log-1",
+                "first_name": "Nina",
+                "studies": [{"degree": "BSc Software Engineering"}],
+                "raw_text": "Education: BSc Software Engineering",
+            },
+            metadata_kind="candidate",
+        )
+    )
+
+    upsert_log = next(
+        item for item in logged if str(item[0]).startswith("Qdrant upsert prepared")
+    )
+    assert document_persistence.QDRANT_CANDIDATES_COLLECTION in upsert_log[1]
+    assert 1 in upsert_log[1]
+    assert "BSc Software Engineering" in str(upsert_log[1])
+    assert any(path == "/collections/candidates/points" for path, _ in logged)
+
+
+def test_ensure_qdrant_collections_creates_dummy_vector_collections(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[tuple[str, dict[str, object]]] = []
+
+    class FakeResponse:
+        def __init__(self, status_code: int = 200) -> None:
+            self.status_code = status_code
+
+        def raise_for_status(self) -> None:
+            return None
+
+    class FakeClient:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        async def __aenter__(self) -> "FakeClient":
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def get(self, path: str) -> FakeResponse:
+            return FakeResponse(status_code=404)
+
+        async def put(self, path: str, **kwargs: object) -> FakeResponse:
+            requests.append((path, kwargs["json"]))
+            return FakeResponse()
+
+    monkeypatch.setattr(document_persistence.httpx, "AsyncClient", FakeClient)
+
+    asyncio.run(document_persistence.ensure_qdrant_collections())
+
+    assert requests == [
+        (
+            "/collections/candidates",
+            {"vectors": {"size": 1, "distance": "Cosine"}},
+        ),
+        (
+            "/collections/insurances",
+            {"vectors": {"size": 1, "distance": "Cosine"}},
+        ),
+    ]


### PR DESCRIPTION
### Motivation
- CV extraction occasionally produced education under alternative keys (e.g. `educations`, `education_history`, `studies`) which were allowed as extra fields by the schema but not mapped to the canonical `education` field, resulting in empty `education` in Qdrant payloads.
- The service uses a dummy vector pipeline (no embeddings yet) but relied on manual collection creation with a vector size of `1`, which was brittle and undocumented at startup.
- Lack of pre-upsert logging made debugging missing structured fields and vector shapes difficult.

### Description
- Add normalization of common candidate education aliases into the canonical `education` key via `_normalize_metadata_aliases`, and apply it before Pydantic validation and record construction in `build_vector_db_metadata` and `build_vector_db_records` (`src/services/document_persistence.py`).
- Standardize dummy-vector behaviour by introducing `QDRANT_DUMMY_VECTOR_SIZE = 1` and `QDRANT_DUMMY_VECTOR = [1.0]` and returning that from `_embedding_vector_for_text` when embeddings are not used (`src/services/document_persistence.py`).
- Add pre-upsert logging `_log_qdrant_upsert` that logs `collection_name`, `vector_length`, the structured candidate object, and full payload (safely JSON-encoded) before calling Qdrant (`src/services/document_persistence.py`).
- Add startup/init logic to ensure the `candidates` and `insurances` Qdrant collections exist with the dummy-vector config, and wire it into the HTTP app lifespan so collections are created automatically if missing (`ensure_qdrant_collections` + `_ensure_qdrant_collection`, and `src/http_api.py` lifespan hook).
- Add unit tests that cover: alias-preservation for `education`, that the produced vector equals `[1.0]`, that upsert logging contains the collection/vector/education content, and that collection initialization issues the expected Qdrant requests (`tests/unit/test_document_persistence.py`).
- Minor: import logger via `logging_config.get_logger()` and use it for the new logging.

### Testing
- Ran code checks with `python -m compileall src` which completed successfully.
- Ran the full unit test suite with `PYTHONPATH=src pytest -q` which passed: `76 passed` and one existing Starlette/httpx deprecation warning. All newly added tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3511c993208328a6e5415de8b3b5e8)