### PR TITLE
fix: canonicalize candidate Qdrant payloads

### DIFF
--- a/src/services/document_persistence.py
+++ b/src/services/document_persistence.py
@@ -37,7 +37,7 @@ class VectorDbMetadataError(ValueError):
 class CandidateVectorMetadata(BaseModel):
     """Candidate table payload used as the source of truth for CV answers."""
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
     id: str = Field(..., min_length=1)
     first_name: str | None = None
@@ -59,6 +59,7 @@ class CandidateVectorMetadata(BaseModel):
     certifications: list[str] | list[dict[str, Any]] = Field(default_factory=list)
     document_hash: str | None = None
     raw_text: str | None = None
+    raw_extraction: dict[str, Any] | None = None
     created_at: str | None = None
     updated_at: str | None = None
 
@@ -278,8 +279,7 @@ async def extract_payload_with_ollama(
     )
     extracted_payload = _parse_json_object(raw_result)
     payload = _with_service_metadata(extracted_payload, document_text, metadata_kind)
-    build_vector_db_metadata(payload, metadata_kind=metadata_kind)
-    return payload
+    return build_vector_db_metadata(payload, metadata_kind=metadata_kind)
 
 
 async def build_answer_from_database_record(
@@ -668,14 +668,56 @@ def _normalize_metadata_aliases(
     if metadata_kind != "candidate":
         return payload
 
-    normalized = dict(payload)
-    if not normalized.get("education"):
-        for alias in ("educations", "education_history", "studies"):
-            alias_value = normalized.get(alias)
-            if alias_value:
-                normalized["education"] = alias_value
-                break
+    schema_fields = set(CandidateVectorMetadata.model_fields)
+    alias_map = {
+        "competencies": "competences",
+        "skills": "competences",
+        "previous_work": "previous_works",
+        "work_experience": "previous_works",
+        "experience": "previous_works",
+        "employment_history": "previous_works",
+        "educations": "education",
+        "education_history": "education",
+        "studies": "education",
+        "languages": "language",
+        "certificates": "certifications",
+        "company": "current_company",
+        "job_title": "current_job_title",
+        "title": "current_job_title",
+    }
+
+    normalized: dict[str, Any] = {}
+    raw_extraction: dict[str, Any] = {}
+    existing_raw_extraction = payload.get("raw_extraction")
+    if isinstance(existing_raw_extraction, dict):
+        raw_extraction.update(existing_raw_extraction)
+
+    for raw_key, value in payload.items():
+        key = _canonical_payload_key(raw_key)
+        target_key = alias_map.get(key, key)
+        if target_key in schema_fields and target_key != "raw_extraction":
+            if target_key != key or str(raw_key) != key:
+                raw_extraction[str(raw_key)] = value
+            if target_key not in normalized or _is_missing_candidate_value(
+                normalized[target_key]
+            ):
+                normalized[target_key] = value
+            continue
+        if key == "raw_extraction":
+            continue
+        raw_extraction[str(raw_key)] = value
+
+    if raw_extraction:
+        normalized["raw_extraction"] = raw_extraction
     return normalized
+
+
+def _canonical_payload_key(key: Any) -> str:
+    return str(key).strip().strip('"').strip("'")
+
+
+def _is_missing_candidate_value(value: Any) -> bool:
+    return value is None or value == "" or value == [] or value == {}
 
 
 def _log_qdrant_upsert(collection_name: str, records: list[VectorDbRecord]) -> None:

--- a/tests/unit/test_document_persistence.py
+++ b/tests/unit/test_document_persistence.py
@@ -596,6 +596,91 @@ def test_candidate_education_alias_is_preserved_in_qdrant_payload() -> None:
     assert len(records[0].vector) == document_persistence.QDRANT_DUMMY_VECTOR_SIZE
 
 
+def test_candidate_payload_normalizes_aliases_without_duplicate_root_keys() -> None:
+    records = build_vector_db_records(
+        {
+            "id": "candidate-canonical-1",
+            "first_name": "Elena",
+            "education": None,
+            '"education"': [
+                {"degree": "MSc Artificial Intelligence"},
+                {"degree": "BSc Computer Science"},
+            ],
+            "work_experience": [
+                {"company": "Acme", "title": "Machine Learning Engineer"}
+            ],
+            "competencies": {"technical": ["Python", "Qdrant"]},
+            "languages": ["English", "Italian"],
+            "company": "Acme",
+            "job_title": "Senior Machine Learning Engineer",
+            "raw_text": "Sample CV with education and work experience",
+        },
+        metadata_kind="candidate",
+    )
+
+    payload = records[0].payload
+
+    assert payload["education"] == [
+        {"degree": "MSc Artificial Intelligence"},
+        {"degree": "BSc Computer Science"},
+    ]
+    assert payload["previous_works"] == [
+        {"company": "Acme", "title": "Machine Learning Engineer"}
+    ]
+    assert payload["competences"] == {"technical": ["Python", "Qdrant"]}
+    assert payload["language"] == ["English", "Italian"]
+    assert payload["current_company"] == "Acme"
+    assert payload["current_job_title"] == "Senior Machine Learning Engineer"
+    assert '"education"' not in payload
+    assert "work_experience" not in payload
+    assert "competencies" not in payload
+    assert "languages" not in payload
+    assert "company" not in payload
+    assert "job_title" not in payload
+    assert payload["raw_extraction"]['"education"'] == [
+        {"degree": "MSc Artificial Intelligence"},
+        {"degree": "BSc Computer Science"},
+    ]
+
+
+def test_database_answer_uses_canonical_candidate_education_in_api_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    saved_record = {
+        "id": "candidate-saved-education",
+        "document_hash": document_persistence._document_hash("CV text"),
+        "first_name": "Elena",
+        "education": [{"degree": "MSc Artificial Intelligence"}],
+        "previous_works": [{"company": "Acme"}],
+    }
+
+    async def fake_get_document_by_hash(collection_name: str, document_hash: str):
+        return saved_record
+
+    async def fake_chat_with_ollama(
+        prompt: str, *, response_format: dict[str, object] | str | None = None
+    ) -> str:
+        assert "MSc Artificial Intelligence" in prompt
+        assert "education" in prompt
+        return "Education: MSc Artificial Intelligence"
+
+    monkeypatch.setattr(
+        document_persistence, "get_document_by_hash", fake_get_document_by_hash
+    )
+    monkeypatch.setattr(document_persistence, "chat_with_ollama", fake_chat_with_ollama)
+    monkeypatch.setattr(
+        document_persistence,
+        "log_performance_event",
+        lambda event, **fields: None,
+    )
+
+    result = asyncio.run(
+        answer_document_prompt_from_database("CV text", "What education does she have?")
+    )
+
+    assert result.response == "Education: MSc Artificial Intelligence"
+
+
 def test_persist_candidate_payload_logs_payload_vector_and_collection(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
### Motivation
- LLM extraction output sometimes injected alias or malformed root keys (e.g. `"education"`, `competencies`, `work_experience`, `company`) alongside canonical fields, which allowed duplicate/inconsistent candidate data to be stored in Qdrant so the UI/API would read empty canonical fields while the real data lived under aliases.
- The change aims to enforce a single canonical candidate payload shape before upsert and preserve raw/unmapped LLM values only under a single debug field.

### Description
- Forbid arbitrary extra root fields on the candidate model by changing `CandidateVectorMetadata` to `model_config = ConfigDict(extra="forbid")` and add a `raw_extraction` field for non-canonical or debugging data.
- Normalize LLM extraction output early by updating `extract_payload_with_ollama` to return the validated canonical metadata (calling `build_vector_db_metadata`) rather than returning the raw service-enriched object for upsert.
- Implement comprehensive alias normalization in `_normalize_metadata_aliases` to map known aliases (e.g. `competencies` → `competences`, `work_experience` → `previous_works`, `education_history`/`"education"` → `education`, `languages` → `language`, `company` → `current_company`, `job_title`/`title` → `current_job_title`) into the canonical schema and collect any non-canonical/malformed keys under `raw_extraction` only.
- Add small helper functions `_canonical_payload_key` and `_is_missing_candidate_value` to safely canonicalize incoming key names and prefer non-empty canonical values when merging.
- Preserve and use the existing `_log_qdrant_upsert` logging to record the final payload (keys and values) immediately before Qdrant upsert so the final shape is observable in logs.
- Add regression tests that assert canonical fields are populated and aliases/malformed keys are not present at the root, and that the database-answer flow uses the canonical `education` field in API responses (`test_candidate_payload_normalizes_aliases_without_duplicate_root_keys` and `test_database_answer_uses_canonical_candidate_education_in_api_response`).

### Testing
- Ran `python -m compileall src` which completed successfully.
- Ran targeted tests with `PYTHONPATH=src pytest tests/unit/test_document_persistence.py` which passed.
- Ran the full unit suite with `PYTHONPATH=src pytest` and observed `78 passed, 1 warning`, confirming the new normalization and logging changes do not break existing behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3515c901c883289a9e46aeb8fa2d7a)