### PR TITLE
fix: preserve CV structured extraction fields

### DIFF
--- a/src/services/document_persistence.py
+++ b/src/services/document_persistence.py
@@ -55,7 +55,7 @@ class CandidateVectorMetadata(BaseModel):
     current_company: str | None = None
     availability_date: str | None = None
     notes: str | None = None
-    language: str | list[str] | None = None
+    languages: str | list[str] | None = None
     certifications: list[str] | list[dict[str, Any]] = Field(default_factory=list)
     document_hash: str | None = None
     raw_text: str | None = None
@@ -277,9 +277,26 @@ async def extract_payload_with_ollama(
     raw_result = await chat_with_ollama(
         prompt, response_format=schema.model_json_schema()
     )
+    logger.info(
+        "Ollama extraction completed metadata_kind=%s extracted_pdf_text_length=%s raw_response=%s",
+        metadata_kind,
+        len(document_text),
+        raw_result,
+    )
     extracted_payload = _parse_json_object(raw_result)
+    logger.info(
+        "Ollama extraction parsed metadata_kind=%s parsed_candidate_object=%s",
+        metadata_kind,
+        _safe_log_json(extracted_payload) if metadata_kind == "candidate" else None,
+    )
     payload = _with_service_metadata(extracted_payload, document_text, metadata_kind)
-    return build_vector_db_metadata(payload, metadata_kind=metadata_kind)
+    metadata = build_vector_db_metadata(payload, metadata_kind=metadata_kind)
+    logger.info(
+        "Ollama extraction canonicalized metadata_kind=%s parsed_candidate_object=%s",
+        metadata_kind,
+        _safe_log_json(metadata) if metadata_kind == "candidate" else None,
+    )
+    return metadata
 
 
 async def build_answer_from_database_record(
@@ -439,13 +456,33 @@ def _build_metadata_extraction_prompt(
         "Normalize explicitly stated dates to YYYY-MM-DD when possible; otherwise "
         "preserve the explicit date text. Normalize explicitly stated money amounts "
         "as numbers and currencies as ISO 4217 codes when possible.\n"
-        "Service-owned fields (id, document_hash, raw_text, created_at, updated_at) "
+        "Service-owned fields (id, document_hash, raw_text, raw_extraction, created_at, updated_at) "
         "should be null unless explicitly present in the document; the service may "
         "overwrite them after extraction.\n"
-        f"Metadata kind: {metadata_kind}.\n"
+        + (_candidate_extraction_instructions() if metadata_kind == "candidate" else "")
+        + f"Metadata kind: {metadata_kind}.\n"
         f"Required top-level fields to populate: {field_names}.\n\n"
         f"JSON Schema:\n{json_schema}\n\n"
         f"Document text:\n{document_text}"
+    )
+
+
+def _candidate_extraction_instructions() -> str:
+    return (
+        "Candidate extraction requirements:\n"
+        "- Return one JSON object using these canonical candidate fields: first_name, "
+        "last_name, email, phone, seniority, city, country, address, "
+        "current_job_title, current_company, education, previous_works, "
+        "competences, languages, certifications, notes.\n"
+        "- Extract education and work experience even when headings or section titles "
+        "vary, are omitted, or are written in another language.\n"
+        "- Preserve every distinct education entry as an object in education.\n"
+        "- Preserve every distinct job, role, internship, contract, or work "
+        "experience entry as an object in previous_works.\n"
+        "- Put skills, technologies, and professional capabilities in competences.\n"
+        "- Put spoken/written languages in languages, not in notes.\n"
+        "- Use null only when information is truly absent, and do not invent "
+        "unstated values.\n"
     )
 
 
@@ -472,7 +509,11 @@ def _parse_json_object(raw_result: str) -> dict[str, Any]:
     try:
         parsed = json.loads(stripped_result)
     except json.JSONDecodeError:
-        parsed = _parse_embedded_json_object(stripped_result)
+        try:
+            parsed = _parse_embedded_json_object(stripped_result)
+        except VectorDbMetadataError:
+            logger.error("Ollama metadata response was not valid JSON raw_response=%s", raw_result)
+            raise
 
     if not isinstance(parsed, dict):
         raise VectorDbMetadataError("Ollama metadata response must be a JSON object.")
@@ -501,6 +542,8 @@ def _with_service_metadata(
     extracted_payload: dict[str, Any], document_text: str, metadata_kind: str
 ) -> dict[str, Any]:
     payload = dict(extracted_payload)
+    if metadata_kind == "candidate":
+        payload["raw_extraction"] = dict(extracted_payload)
     document_hash = _document_hash(document_text)
     timestamp = _utc_timestamp()
     payload["id"] = _service_document_id(payload.get("id"), document_hash, metadata_kind)
@@ -679,7 +722,7 @@ def _normalize_metadata_aliases(
         "educations": "education",
         "education_history": "education",
         "studies": "education",
-        "languages": "language",
+        "language": "languages",
         "certificates": "certifications",
         "company": "current_company",
         "job_title": "current_job_title",

--- a/tests/unit/test_document_persistence.py
+++ b/tests/unit/test_document_persistence.py
@@ -60,7 +60,7 @@ def test_candidate_schema_contains_required_table_fields() -> None:
         "current_company",
         "availability_date",
         "notes",
-        "language",
+        "languages",
         "certifications",
         "created_at",
         "updated_at",
@@ -104,7 +104,7 @@ def test_build_metadata_extraction_prompt_contains_strict_schema_instructions() 
     assert "The document may be written in any language." in prompt
     assert '"first_name"' in prompt
     assert '"previous_works"' in prompt
-    assert '"language"' in prompt
+    assert '"languages"' in prompt
     assert '"certifications"' in prompt
     assert "Jane Doe" in prompt
 
@@ -165,7 +165,7 @@ def test_extract_payload_with_ollama_uses_candidate_schema_format_and_service_me
                 "current_company": "Acme",
                 "availability_date": None,
                 "notes": None,
-                "language": ["Italiano"],
+                "languages": ["Italiano"],
                 "certifications": [],
                 "created_at": None,
                 "updated_at": None,
@@ -283,7 +283,7 @@ def test_build_vector_metadata_uses_extracted_candidate_payload_values() -> None
         "competences": {"technical": ["rust", "python"]},
         "education": [{"degree": "MSc Computer Science"}],
         "certifications": ["Kubernetes Administrator"],
-        "language": ["English", "French"],
+        "languages": ["English", "French"],
         "current_job_title": "Principal Engineer",
         "current_company": "Acme",
         "raw_text": "Candidate profile",
@@ -299,7 +299,7 @@ def test_build_vector_metadata_uses_extracted_candidate_payload_values() -> None
     assert metadata["competences"] == {"technical": ["rust", "python"]}
     assert metadata["education"] == [{"degree": "MSc Computer Science"}]
     assert metadata["certifications"] == ["Kubernetes Administrator"]
-    assert metadata["language"] == ["English", "French"]
+    assert metadata["languages"] == ["English", "French"]
 
 
 def test_build_vector_metadata_allows_missing_optional_candidate_fields() -> None:
@@ -323,7 +323,7 @@ def test_build_vector_metadata_allows_missing_optional_candidate_fields() -> Non
     assert metadata["current_company"] is None
     assert metadata["availability_date"] is None
     assert metadata["notes"] is None
-    assert metadata["language"] is None
+    assert metadata["languages"] is None
     assert metadata["certifications"] == []
 
 
@@ -391,7 +391,7 @@ def test_database_first_workflow_uses_existing_candidate_without_extraction(
         "first_name": "Ada",
         "last_name": "Lovelace",
         "certifications": ["Math"],
-        "language": ["English"],
+        "languages": ["English"],
     }
 
     async def fake_infer(document_text: str, question: str) -> str:
@@ -628,13 +628,13 @@ def test_candidate_payload_normalizes_aliases_without_duplicate_root_keys() -> N
         {"company": "Acme", "title": "Machine Learning Engineer"}
     ]
     assert payload["competences"] == {"technical": ["Python", "Qdrant"]}
-    assert payload["language"] == ["English", "Italian"]
+    assert payload["languages"] == ["English", "Italian"]
     assert payload["current_company"] == "Acme"
     assert payload["current_job_title"] == "Senior Machine Learning Engineer"
     assert '"education"' not in payload
     assert "work_experience" not in payload
     assert "competencies" not in payload
-    assert "languages" not in payload
+    assert "language" not in payload
     assert "company" not in payload
     assert "job_title" not in payload
     assert payload["raw_extraction"]['"education"'] == [
@@ -778,3 +778,114 @@ def test_ensure_qdrant_collections_creates_dummy_vector_collections(
             {"vectors": {"size": 1, "distance": "Cosine"}},
         ),
     ]
+
+
+def test_cv_workflow_saves_ollama_extracted_canonical_candidate_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sample_cv_text = (
+        "Alex Morgan\n"
+        "Milan, Italy | alex@example.com\n"
+        "Professional background\n"
+        "Senior Data Engineer at Relewant from 2021 to present.\n"
+        "Earlier Software Engineer at Example Labs from 2018 to 2021.\n"
+        "Academic background\n"
+        "MSc Computer Science, Politecnico di Milano, 2018.\n"
+        "Skills: Python, Qdrant, ETL. Languages: English, Italian."
+    )
+    calls: dict[str, object] = {"get_count": 0}
+
+    async def fake_get_document_by_hash(collection_name: str, document_hash: str):
+        calls["get_count"] = int(calls["get_count"]) + 1
+        if calls["get_count"] < 3:
+            return None
+        return calls["stored_payload"]
+
+    async def fake_chat_with_ollama(
+        prompt: str, *, response_format: dict[str, object] | str | None = None
+    ) -> str:
+        if "Classify the uploaded document" in prompt:
+            return '{"document_type":"cv"}'
+        if "information extraction system" in prompt:
+            calls["extraction_prompt"] = prompt
+            return json.dumps(
+                {
+                    "id": None,
+                    "first_name": "Alex",
+                    "last_name": "Morgan",
+                    "email": "alex@example.com",
+                    "phone": None,
+                    "seniority": "senior",
+                    "city": "Milan",
+                    "country": "Italy",
+                    "address": None,
+                    "current_job_title": "Senior Data Engineer",
+                    "current_company": "Relewant",
+                    "education": [
+                        {
+                            "degree": "MSc Computer Science",
+                            "institution": "Politecnico di Milano",
+                            "year": "2018",
+                        }
+                    ],
+                    "previous_works": [
+                        {
+                            "title": "Senior Data Engineer",
+                            "company": "Relewant",
+                            "start_date": "2021",
+                            "end_date": "present",
+                        },
+                        {
+                            "title": "Software Engineer",
+                            "company": "Example Labs",
+                            "start_date": "2018",
+                            "end_date": "2021",
+                        },
+                    ],
+                    "competences": ["Python", "Qdrant", "ETL"],
+                    "languages": ["English", "Italian"],
+                    "certifications": [],
+                    "notes": None,
+                    "availability_date": None,
+                    "created_at": None,
+                    "updated_at": None,
+                }
+            )
+        calls["answer_prompt"] = prompt
+        return "Alex Morgan was saved."
+
+    async def fake_upsert_records(collection_name: str, records: list[object]) -> None:
+        calls["collection_name"] = collection_name
+        calls["stored_payload"] = records[0].payload
+
+    monkeypatch.setattr(
+        document_persistence, "get_document_by_hash", fake_get_document_by_hash
+    )
+    monkeypatch.setattr(document_persistence, "chat_with_ollama", fake_chat_with_ollama)
+    monkeypatch.setattr(document_persistence, "_upsert_records", fake_upsert_records)
+    monkeypatch.setattr(
+        document_persistence,
+        "log_performance_event",
+        lambda event, **fields: None,
+    )
+
+    result = asyncio.run(
+        answer_document_prompt_from_database(sample_cv_text, "Summarize this CV")
+    )
+
+    payload = calls["stored_payload"]
+    assert result.document_type == "cv"
+    assert calls["collection_name"] == document_persistence.QDRANT_CANDIDATES_COLLECTION
+    assert payload["education"]
+    assert payload["previous_works"]
+    assert payload["education"][0]["degree"] == "MSc Computer Science"
+    assert payload["previous_works"][0]["company"] == "Relewant"
+    assert payload["current_job_title"] == "Senior Data Engineer"
+    assert payload["current_company"] == "Relewant"
+    assert payload["competences"] == ["Python", "Qdrant", "ETL"]
+    assert payload["languages"] == ["English", "Italian"]
+    assert "language" not in payload
+    assert "work_experience" not in payload
+    assert "education_history" not in payload
+    assert "raw_extraction" in payload
+    assert "education and work experience" in calls["extraction_prompt"].lower()


### PR DESCRIPTION
### Motivation
- CV uploads were losing education and previous-work information when saving to Qdrant because the LLM extraction, parsing, normalization, and persistence flow did not guarantee the canonical candidate schema was produced and persisted. 
- The intended workflow is for Ollama to perform structured extraction (not keyword heuristics) and for the service to validate/normalize that JSON into the canonical `candidates` payload before upsert.

### Description
- Strengthen Ollama extraction: the candidate metadata prompt now includes explicit candidate extraction instructions (preserve multiple education and work entries, return only valid JSON, do not invent values, use nulls for absent scalars). (changes in `extract` prompt and new helper `_candidate_extraction_instructions`).
- Preserve raw model output and normalize into canonical payload: the raw Ollama JSON is saved under `raw_extraction` and the service normalizes aliases (e.g. `work_experience` → `previous_works`, `language` → `languages`) and validates against `CandidateVectorMetadata` before building the Qdrant payload. (`_with_service_metadata`, `_normalize_metadata_aliases`, `build_vector_db_metadata`).
- Robust parsing and logging: added logging of extracted PDF text length, raw Ollama response, parsed LLM object, and canonicalized metadata; JSON parsing now logs raw response on failure for clearer errors. (`extract_payload_with_ollama`, `_parse_json_object`).
- Schema and small API changes: canonicalized the candidate field name to `languages` and preserved alias mapping for legacy/model variants; final Qdrant payload is produced only from the validated canonical model. Added one unit test exercising the full CV extraction→upsert flow with a sample CV. (`CandidateVectorMetadata` and tests updated/added).

### Testing
- Ran unit tests: `PYTHONPATH=src pytest -q` — all tests passed (79 passed, 1 warning). 
- Ran focused module tests: `PYTHONPATH=src pytest tests/unit/test_document_persistence.py -q` — passed (25 tests).
- Ran static validation: `PYTHONPATH=src python -m compileall src` — compiled without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a351b3d61388328b182a15ed26d1474)