### PR TITLE
fix: omit raw text from vector payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Document-processing blueprints include a `cv-reader-agent` for reading CVs, resu
 - `candidate-profile-extraction`
 - `experience-skills-normalization`
 
-The CV reader agent extracts evidence-backed candidate facts, timelines, education, certifications, projects, skills, and review warnings from supplied document text while protecting PII and avoiding unsupported hiring decisions. Persisted candidate payloads support the `language` field and the `certifications` field alongside JSON payloads for `competences`, `previous_works`, and `education`.
+The CV reader agent extracts evidence-backed candidate facts, timelines, education, certifications, projects, skills, and review warnings from supplied document text while protecting PII and avoiding unsupported hiring decisions. Persisted candidate payloads support the `languages` field as a list of values and the `certifications` field alongside JSON payloads for `competences`, `previous_works`, and `education`.
 
 ## Rotative logs for MCP tools
 
@@ -205,7 +205,7 @@ Successful responses contain only the answer as `{"response":"result based on th
 
 Expected PDF workflow: upload PDF → detect document type → check the matching database collection → if the record exists, retrieve it and answer from database fields only → if the record is missing, extract structured data once with Ollama, save it, retrieve the saved record, and answer from database fields only. CVs use the `candidates` collection; insurance documents use the `insurances` collection. The removed legacy workflow no longer asks Ollama to answer from PDF text before reprocessing the same PDF for extraction.
 
-Candidate records support `id`, `first_name`, `last_name`, `email`, `phone`, `seniority`, `city`, `country`, `address`, `competences`, `previous_works`, `education`, `current_job_title`, `current_company`, `availability_date`, `notes`, `language`, `certifications`, `created_at`, and `updated_at`. Insurance records support `id`, `candidate_id`, `policy_number`, `insurance_provider`, `insurance_type`, `policy_holder`, `coverage_details`, `start_date`, `end_date`, `premium_amount`, `currency`, `beneficiary`, `created_at`, and `updated_at`. The service also stores operational `document_hash` values to detect duplicates and uses `raw_text` only for indexing/storage, not for answer prompts.
+Candidate records support `id`, `first_name`, `last_name`, `email`, `phone`, `seniority`, `city`, `country`, `address`, `competences`, `previous_works`, `education`, `current_job_title`, `current_company`, `availability_date`, `notes`, `languages`, `certifications`, `created_at`, and `updated_at`. Insurance records support `id`, `candidate_id`, `policy_number`, `insurance_provider`, `insurance_type`, `policy_holder`, `coverage_details`, `start_date`, `end_date`, `premium_amount`, `currency`, `beneficiary`, `created_at`, and `updated_at`. The service also stores operational `document_hash` values to detect duplicates; raw PDF text is not persisted in Qdrant payloads or answer prompts.
 
 ### POST `/api/prompts/execute`
 

--- a/src/services/document_persistence.py
+++ b/src/services/document_persistence.py
@@ -55,13 +55,23 @@ class CandidateVectorMetadata(BaseModel):
     current_company: str | None = None
     availability_date: str | None = None
     notes: str | None = None
-    languages: str | list[str] | None = None
+    languages: list[str] = Field(default_factory=list)
     certifications: list[str] | list[dict[str, Any]] = Field(default_factory=list)
     document_hash: str | None = None
-    raw_text: str | None = None
     raw_extraction: dict[str, Any] | None = None
     created_at: str | None = None
     updated_at: str | None = None
+
+    @field_validator(
+        "previous_works", "education", "languages", "certifications", mode="before"
+    )
+    @classmethod
+    def repeated_fields_must_be_lists(cls, value: Any) -> list[Any]:
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return value
+        return [value]
 
 
 class InsuranceVectorMetadata(BaseModel):
@@ -82,7 +92,6 @@ class InsuranceVectorMetadata(BaseModel):
     currency: str | None = None
     beneficiary: dict[str, Any] | None = None
     document_hash: str | None = None
-    raw_text: str | None = None
     created_at: str | None = None
     updated_at: str | None = None
 
@@ -93,7 +102,6 @@ class GenericVectorMetadata(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     id: str = Field(..., min_length=1)
-    raw_text: str | None = None
 
 
 class VectorDbRecord(BaseModel):
@@ -361,13 +369,18 @@ def build_vector_db_records(
     *,
     metadata_kind: str | None = None,
 ) -> list[VectorDbRecord]:
+    raw_embedding_text = extracted_payload.get("raw_text")
     normalized_payload = _normalize_metadata_aliases(
         extracted_payload, metadata_kind=metadata_kind
     )
     metadata = build_vector_db_metadata(
         normalized_payload, metadata_kind=metadata_kind
     )
-    embedding_text = _embedding_text_from_payload(metadata)
+    embedding_text = (
+        raw_embedding_text
+        if isinstance(raw_embedding_text, str) and raw_embedding_text
+        else _embedding_text_from_payload(metadata)
+    )
     chunks = (
         [embedding_text]
         if metadata_kind == "insurance"
@@ -393,6 +406,7 @@ def build_vector_db_metadata(
     normalized_payload = _normalize_metadata_aliases(
         extracted_payload, metadata_kind=metadata_kind
     )
+    normalized_payload = _without_collection_excluded_fields(normalized_payload)
     schema = _metadata_schema(metadata_kind)
     try:
         metadata_model = schema.model_validate(normalized_payload)
@@ -456,7 +470,7 @@ def _build_metadata_extraction_prompt(
         "Normalize explicitly stated dates to YYYY-MM-DD when possible; otherwise "
         "preserve the explicit date text. Normalize explicitly stated money amounts "
         "as numbers and currencies as ISO 4217 codes when possible.\n"
-        "Service-owned fields (id, document_hash, raw_text, raw_extraction, created_at, updated_at) "
+        "Service-owned fields (id, document_hash, raw_extraction, created_at, updated_at) "
         "should be null unless explicitly present in the document; the service may "
         "overwrite them after extraction.\n"
         + (_candidate_extraction_instructions() if metadata_kind == "candidate" else "")
@@ -548,7 +562,6 @@ def _with_service_metadata(
     timestamp = _utc_timestamp()
     payload["id"] = _service_document_id(payload.get("id"), document_hash, metadata_kind)
     payload["document_hash"] = document_hash
-    payload["raw_text"] = document_text
     payload["created_at"] = payload.get("created_at") or timestamp
     payload["updated_at"] = timestamp
     return payload
@@ -680,6 +693,13 @@ def _embedding_text_from_payload(metadata: dict[str, Any]) -> str:
     return " ".join(str(value) for value in metadata.values() if value is not None)
 
 
+def _without_collection_excluded_fields(payload: dict[str, Any]) -> dict[str, Any]:
+    collection_excluded_keys = {"raw_text"}
+    return {
+        key: value for key, value in payload.items() if key not in collection_excluded_keys
+    }
+
+
 def _split_embedding_text(text: str) -> list[str]:
     if not text:
         return [""]
@@ -737,6 +757,8 @@ def _normalize_metadata_aliases(
 
     for raw_key, value in payload.items():
         key = _canonical_payload_key(raw_key)
+        if key == "raw_text":
+            continue
         target_key = alias_map.get(key, key)
         if target_key in schema_fields and target_key != "raw_extraction":
             if target_key != key or str(raw_key) != key:

--- a/tests/unit/test_document_persistence.py
+++ b/tests/unit/test_document_persistence.py
@@ -183,9 +183,7 @@ def test_extract_payload_with_ollama_uses_candidate_schema_format_and_service_me
 
     assert payload["id"].startswith("candidate-")
     assert payload["document_hash"]
-    assert payload["raw_text"] == (
-        "Curriculum vitae\nGiulia Bianchi\nIstruzione: Laurea in Informatica"
-    )
+    assert "raw_text" not in payload
     assert payload["first_name"] == "Giulia"
     assert payload["education"] == [{"degree": "Laurea in Informatica"}]
     assert captured["response_format"] == CandidateVectorMetadata.model_json_schema()
@@ -323,7 +321,7 @@ def test_build_vector_metadata_allows_missing_optional_candidate_fields() -> Non
     assert metadata["current_company"] is None
     assert metadata["availability_date"] is None
     assert metadata["notes"] is None
-    assert metadata["languages"] is None
+    assert metadata["languages"] == []
     assert metadata["certifications"] == []
 
 


### PR DESCRIPTION
### Motivation
- Prevent persisting raw PDF text in Qdrant payloads and ensure fields that can contain multiple values are always stored as lists (e.g., `languages`).
- Keep raw text available for embedding/chunking only as transient input while the canonical persisted metadata remains compact and schema-compliant.

### Description
- Removed `raw_text` from the persisted metadata schemas for candidates, insurances, and generic metadata and stopped adding `raw_text` in service-owned extraction payloads.
- Made `languages` a list with a default empty list and added a `@field_validator` to normalize repeated candidate fields (`previous_works`, `education`, `languages`, `certifications`) into lists before validation.
- Added `_without_collection_excluded_fields` to strip collection-excluded keys (currently `raw_text`) before model validation and updated `build_vector_db_metadata` to use it.
- Preserved `raw_text` only transiently for embedding/chunking by reading it from `extracted_payload` inside `build_vector_db_records` and skipping it during alias normalization so it is not persisted in payloads.
- Updated `_normalize_metadata_aliases` to ignore `raw_text` and adjusted prompts/docs/tests to reflect the new shape (`languages` plural list, `raw_text` not persisted).

### Testing
- Ran `python -m compileall src` which completed successfully.
- Ran `PYTHONPATH=src pytest -q` which passed the full test suite (`79 passed`, 1 deprecation warning).
- Verified targeted unit tests for document persistence during development and updated tests to assert `raw_text` is no longer present and repeated fields normalize to lists.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a351ed973a48328823ae6cd5d5eaa70)