### PR TITLE
fix: stabilize CV anonymization sections

### DIFF
--- a/src/services/cv_anonymization.py
+++ b/src/services/cv_anonymization.py
@@ -1,8 +1,51 @@
 from __future__ import annotations
 
+import re
+
 from fastmcp.exceptions import ToolError
 
 from clients.ollama import chat_with_ollama
+
+REQUIRED_CV_SECTIONS = (
+    "Personal data",
+    "Experience",
+    "Education",
+    "Skills",
+    "Certifications",
+    "Hobby",
+)
+
+_SECTION_ALIASES = {
+    "personal data": "Personal data",
+    "anagraphical data": "Personal data",
+    "anagrafical data": "Personal data",
+    "contact": "Personal data",
+    "contact information": "Personal data",
+    "profile": "Personal data",
+    "summary": "Personal data",
+    "professional summary": "Personal data",
+    "experience": "Experience",
+    "work experience": "Experience",
+    "professional experience": "Experience",
+    "employment history": "Experience",
+    "work history": "Experience",
+    "career history": "Experience",
+    "education": "Education",
+    "academic background": "Education",
+    "academic history": "Education",
+    "qualifications": "Education",
+    "skills": "Skills",
+    "technical skills": "Skills",
+    "competences": "Skills",
+    "competencies": "Skills",
+    "certifications": "Certifications",
+    "certificates": "Certifications",
+    "licenses": "Certifications",
+    "licences": "Certifications",
+    "hobby": "Hobby",
+    "hobbies": "Hobby",
+    "interests": "Hobby",
+}
 
 CV_ANONYMIZATION_PROMPT_TEMPLATE = """You anonymize and format CV content for PDF export.
 
@@ -15,20 +58,29 @@ Privacy rules:
 - Remove house numbers.
 - Remove postal codes.
 - Keep only the city from any address, for example "Via Roma 10, 6900 Lugano, Switzerland" becomes "Lugano".
-- Preserve professional experience, education, skills, certifications, languages, projects, technical competencies, hobbies, and professional summary when present.
-- Remove or transform all personally identifiable information other than the candidate first/given name.
+- Preserve all non-sensitive professional information: professional summary, experience, job titles, employers, dates, responsibilities, achievements, education, skills, certifications, languages, projects, technical competencies, and hobbies.
+- Anonymize personal/sensitive data only. Do not remove professional content unless it contains personal identifying data.
+- Never invent missing information.
+
+Classification rules:
+- Classify all CV content into the most appropriate required section.
+- Treat alternative headings such as "Work History" as Experience, "Academic Background" as Education, "Technical Skills" as Skills, and "Interests" as Hobby.
+- Keep certifications and licenses in Certifications, not Education or Skills.
+- Keep hobbies, interests, and extracurricular non-professional activities in Hobby.
 
 Formatting rules:
-- Return the anonymized CV using exactly these sections and this order:
-  1. Anagraphical data
+- You must output exactly these sections and in this order:
+  1. Personal data
   2. Experience
   3. Education
   4. Skills
   5. Certifications
   6. Hobby
-- Section titles must be bold in the exported PDF. Mark each section title with markdown bold delimiters, for example **Anagraphical data**, so the renderer can draw real bold text without showing the delimiters.
+- Never drop a section heading. Do not duplicate section headings.
+- Section titles must be bold in the exported PDF. Mark each section title with markdown bold delimiters, for example **Personal data**, so the renderer can draw real bold text without showing the delimiters.
 - Use only round bullet points for lists; never use square bullet points.
-- If a section has no supported content in the CV, include the bold section title and write a round bullet point with "Not specified".
+- For each section, include all relevant anonymized content found in the input CV.
+- If no relevant content exists for a section, include the bold section title and write a round bullet point with "Not specified".
 
 Output rules:
 - Return only the formatted anonymized CV content.
@@ -51,7 +103,77 @@ async def anonymize_cv_text(cv_text: str) -> str:
     anonymized_text = _remove_introductory_sentence(response.strip())
     if not anonymized_text:
         raise ToolError("Ollama returned an empty anonymized CV response.")
-    return anonymized_text
+    return normalize_cv_sections(anonymized_text)
+
+
+def normalize_cv_sections(anonymized_text: str) -> str:
+    """Return anonymized CV text with one complete, ordered section set."""
+    section_content = {section: [] for section in REQUIRED_CV_SECTIONS}
+    current_section: str | None = None
+    preamble: list[str] = []
+
+    for raw_line in anonymized_text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        section = _section_from_heading(line)
+        if section:
+            current_section = section
+            continue
+        if current_section is None:
+            preamble.append(_normalize_content_line(line))
+            continue
+        section_content[current_section].append(_normalize_content_line(line))
+
+    if preamble:
+        section_content["Personal data"] = preamble + section_content["Personal data"]
+
+    normalized_lines: list[str] = []
+    for section in REQUIRED_CV_SECTIONS:
+        if normalized_lines:
+            normalized_lines.append("")
+        normalized_lines.append(f"**{section}**")
+        content = _dedupe_content(section_content[section])
+        if not content:
+            normalized_lines.append("• Not specified")
+            continue
+        normalized_lines.extend(content)
+
+    return "\n".join(normalized_lines)
+
+
+def _section_from_heading(line: str) -> str | None:
+    normalized = _normalize_heading_text(line)
+    return _SECTION_ALIASES.get(normalized)
+
+
+def _normalize_heading_text(line: str) -> str:
+    heading = line.strip()
+    heading = re.sub(r"\*\*([^*]+)\*\*", r"\1", heading).strip()
+    heading = heading.strip("#:")
+    heading = re.sub(r"^[-*•▪■□\s]+", "", heading).strip()
+    heading = heading.rstrip(":").strip()
+    return re.sub(r"\s+", " ", heading).casefold()
+
+
+def _normalize_content_line(line: str) -> str:
+    text = re.sub(r"^[▪■□]\s*", "• ", line.strip())
+    text = re.sub(r"^[-*]\s+", "• ", text)
+    if not text.startswith("•"):
+        return f"• {text}"
+    return re.sub(r"^•\s*", "• ", text)
+
+
+def _dedupe_content(lines: list[str]) -> list[str]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for line in lines:
+        key = line.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(line)
+    return deduped
 
 
 def _remove_introductory_sentence(anonymized_text: str) -> str:

--- a/tests/unit/test_cv_export.py
+++ b/tests/unit/test_cv_export.py
@@ -10,6 +10,16 @@ from starlette.datastructures import Headers, UploadFile
 from services import cv_anonymization, cv_extraction, cv_pdf_rendering
 
 
+EXPECTED_SECTION_HEADINGS = [
+    "**Personal data**",
+    "**Experience**",
+    "**Education**",
+    "**Skills**",
+    "**Certifications**",
+    "**Hobby**",
+]
+
+
 def make_upload(
     filename: str = "cv.pdf",
     content_type: str = "application/pdf",
@@ -28,13 +38,13 @@ def test_extract_cv_text_from_upload_writes_pdf_and_extracts_text(monkeypatch: p
     def fake_extract_pdf_text(file_path: str) -> str:
         captured["file_path"] = file_path
         captured["exists_during_extraction"] = Path(file_path).is_file()
-        return "Gabriele Di Somma\nSenior Developer"
+        return "Gabriele\nSenior Developer"
 
     monkeypatch.setattr(cv_extraction, "extract_pdf_text", fake_extract_pdf_text)
 
     result = asyncio.run(cv_extraction.extract_cv_text_from_upload(make_upload()))
 
-    assert result == "Gabriele Di Somma\nSenior Developer"
+    assert result == "Gabriele\nSenior Developer"
     assert captured["file_path"].endswith("cv-upload.pdf")
     assert captured["exists_during_extraction"] is True
 
@@ -50,8 +60,8 @@ def test_anonymize_cv_text_uses_ollama_prompt(monkeypatch: pytest.MonkeyPatch) -
     async def fake_chat_with_ollama(prompt: str, **_: object) -> str:
         captured["prompt"] = prompt
         return (
-            "**Anagraphical data**\n"
-            "• Gabriele Di Somma\n"
+            "**Personal data**\n"
+            "• Gabriele\n"
             "• Lugano\n"
             "**Experience**\n"
             "• Senior Developer"
@@ -61,16 +71,29 @@ def test_anonymize_cv_text_uses_ollama_prompt(monkeypatch: pytest.MonkeyPatch) -
 
     result = asyncio.run(
         cv_anonymization.anonymize_cv_text(
-            "Gabriele Di Somma\ngabriele@example.com\nVia Roma 10, Lugano"
+            "Gabriele\ngabriele@example.com\nVia Roma 10, Lugano"
         )
     )
 
     assert result == (
-        "**Anagraphical data**\n"
-        "• Gabriele Di Somma\n"
+        "**Personal data**\n"
+        "• Gabriele\n"
         "• Lugano\n"
+        "\n"
         "**Experience**\n"
-        "• Senior Developer"
+        "• Senior Developer\n"
+        "\n"
+        "**Education**\n"
+        "• Not specified\n"
+        "\n"
+        "**Skills**\n"
+        "• Not specified\n"
+        "\n"
+        "**Certifications**\n"
+        "• Not specified\n"
+        "\n"
+        "**Hobby**\n"
+        "• Not specified"
     )
     assert "Keep only the candidate first/given name" in captured["prompt"]
     assert "Remove phone numbers" in captured["prompt"]
@@ -79,7 +102,7 @@ def test_anonymize_cv_text_uses_ollama_prompt(monkeypatch: pytest.MonkeyPatch) -
     assert "Remove house numbers" in captured["prompt"]
     assert "Remove postal codes" in captured["prompt"]
     assert "Keep only the city" in captured["prompt"]
-    assert "Anagraphical data" in captured["prompt"]
+    assert "Personal data" in captured["prompt"]
     assert "Experience" in captured["prompt"]
     assert "Education" in captured["prompt"]
     assert "Skills" in captured["prompt"]
@@ -94,13 +117,93 @@ def test_anonymize_cv_text_uses_ollama_prompt(monkeypatch: pytest.MonkeyPatch) -
 
 def test_anonymize_cv_text_removes_introductory_sentence(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_chat_with_ollama(prompt: str, **_: object) -> str:
-        return "Here is the anonymized CV content for PDF export:\nLugano\nSenior Developer"
+        return "Here is the anonymized CV content for PDF export:\n**Personal data**\n• Lugano"
 
     monkeypatch.setattr(cv_anonymization, "chat_with_ollama", fake_chat_with_ollama)
 
     result = asyncio.run(cv_anonymization.anonymize_cv_text("Gabriele Di Somma"))
 
-    assert result == "Lugano\nSenior Developer"
+    assert result == (
+        "**Personal data**\n"
+        "• Lugano\n"
+        "\n"
+        "**Experience**\n"
+        "• Not specified\n"
+        "\n"
+        "**Education**\n"
+        "• Not specified\n"
+        "\n"
+        "**Skills**\n"
+        "• Not specified\n"
+        "\n"
+        "**Certifications**\n"
+        "• Not specified\n"
+        "\n"
+        "**Hobby**\n"
+        "• Not specified"
+    )
+
+
+def test_normalize_cv_sections_keeps_all_sections_when_present() -> None:
+    text = (
+        "**Personal data**\n"
+        "• Ada\n"
+        "**Experience**\n"
+        "• Backend Engineer at ExampleCo\n"
+        "**Education**\n"
+        "• MSc Computer Science\n"
+        "**Skills**\n"
+        "• Python\n"
+        "**Certifications**\n"
+        "• AWS Cloud Practitioner\n"
+        "**Hobby**\n"
+        "• Hiking"
+    )
+
+    result = cv_anonymization.normalize_cv_sections(text)
+
+    assert [line for line in result.splitlines() if line.startswith("**")] == EXPECTED_SECTION_HEADINGS
+    assert "• Backend Engineer at ExampleCo" in result
+    assert "• MSc Computer Science" in result
+    assert "• Python" in result
+    assert "• AWS Cloud Practitioner" in result
+    assert "• Hiking" in result
+
+
+def test_normalize_cv_sections_restores_missing_sections() -> None:
+    result = cv_anonymization.normalize_cv_sections(
+        "**Personal data**\n• Ada\n**Experience**\n• Backend Engineer\n**Skills**\n• Python"
+    )
+
+    assert [line for line in result.splitlines() if line.startswith("**")] == EXPECTED_SECTION_HEADINGS
+    assert result.count("**Education**") == 1
+    assert result.count("**Certifications**") == 1
+    assert result.count("**Hobby**") == 1
+    assert result.count("• Not specified") == 3
+
+
+def test_normalize_cv_sections_maps_alternative_section_titles() -> None:
+    result = cv_anonymization.normalize_cv_sections(
+        "Contact\n"
+        "• Ada\n"
+        "Work History\n"
+        "• Platform Engineer\n"
+        "Academic Background\n"
+        "• BSc Informatics\n"
+        "Technical Skills\n"
+        "• Python\n"
+        "Certificates\n"
+        "• Kubernetes Administrator\n"
+        "Interests\n"
+        "• Climbing"
+    )
+
+    assert [line for line in result.splitlines() if line.startswith("**")] == EXPECTED_SECTION_HEADINGS
+    assert result.index("• Platform Engineer") < result.index("**Education**")
+    assert "• BSc Informatics" in result
+    assert "• Python" in result
+    assert "• Kubernetes Administrator" in result
+    assert "• Climbing" in result
 
 
 def test_anonymize_cv_text_rejects_empty_ollama_response(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -172,7 +275,7 @@ def test_render_anonymized_cv_pdf_one_page_cv_is_rendered_once(tmp_path: Path) -
     output_path = tmp_path / "anonymized-cv.pdf"
     text = (
         "Here is the anonymized CV content for PDF export:\n"
-        "**Anagraphical data**\n"
+        "**Personal data**\n"
         "• Gabriele\n"
         "• Lugano\n"
         "**Experience**\n"
@@ -196,7 +299,7 @@ def test_render_anonymized_cv_pdf_one_page_cv_is_rendered_once(tmp_path: Path) -
 
     assert len(page_texts) == 1
     assert "Here is the anonymized CV content for PDF export:" not in full_text
-    assert full_text.count("Anagraphical data") == 1
+    assert full_text.count("Personal data") == 1
     assert full_text.count("Experience") == 1
     assert full_text.count("Senior Developer") == 1
     assert full_text.count("Skills") == 1
@@ -353,7 +456,7 @@ def test_write_text_overlay_single_page_does_not_duplicate_content(tmp_path: Pat
 
     overlay_path = tmp_path / "single-page-overlay.pdf"
     text = (
-        "**Anagraphical data**\n"
+        "**Personal data**\n"
         "• Candidate\n"
         "**Experience**\n"
         "• Developer\n"


### PR DESCRIPTION
### Motivation
- Ollama responses occasionally omitted one or more CV sections even when the extracted text contained that data, causing unstable anonymized CV exports.
- The goal is to make the anonymization output deterministic: always emit the six required headings in the exact order and never invent or drop information.

### Description
- Strengthened the anonymization prompt in `src/services/cv_anonymization.py` to instruct the model to output exactly these sections in order: `Personal data`, `Experience`, `Education`, `Skills`, `Certifications`, `Hobby`, preserve non-sensitive professional info, and never invent missing data.
- Added a deterministic post-processing normalizer `normalize_cv_sections` that enforces the required section order, maps common heading aliases (e.g., "Work History" → `Experience`, "Academic Background" → `Education`, "Technical Skills" → `Skills`, "Interests" → `Hobby`), normalizes bullets, deduplicates lines, and inserts `• Not specified` for empty sections.
- Kept the existing behavior of removing an introductory sentence via `_remove_introductory_sentence` and integrated the validator to run after the model response; replaced previous free-form return with `normalize_cv_sections` output.
- Updated unit tests in `tests/unit/test_cv_export.py` to cover: all sections present, missing sections restored with `Not specified`, and alternative section titles mapping to the canonical sections.

### Testing
- Ran `python -m compileall src` and compilation succeeded without errors.
- Ran unit tests for the CV export module with `PYTHONPATH=src pytest tests/unit/test_cv_export.py` and they passed (19 tests passed).
- Ran the full test suite with `PYTHONPATH=src pytest` and all tests passed (81 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a3ecd54448328b0f408c0dba98a78)