### PR TITLE
fix: repair CV anonymization pipeline

### DIFF
--- a/src/services/cv_anonymization.py
+++ b/src/services/cv_anonymization.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import re
-
 from fastmcp.exceptions import ToolError
 
 from clients.ollama import chat_with_ollama
@@ -15,39 +13,14 @@ REQUIRED_CV_SECTIONS = (
     "Hobby",
 )
 
-_SECTION_ALIASES = {
-    "personal data": "Personal data",
-    "anagraphical data": "Personal data",
-    "anagrafical data": "Personal data",
-    "contact": "Personal data",
-    "contact information": "Personal data",
-    "profile": "Personal data",
-    "summary": "Personal data",
-    "professional summary": "Personal data",
-    "experience": "Experience",
-    "work experience": "Experience",
-    "professional experience": "Experience",
-    "employment history": "Experience",
-    "work history": "Experience",
-    "career history": "Experience",
-    "education": "Education",
-    "academic background": "Education",
-    "academic history": "Education",
-    "qualifications": "Education",
-    "skills": "Skills",
-    "technical skills": "Skills",
-    "competences": "Skills",
-    "competencies": "Skills",
-    "certifications": "Certifications",
-    "certificates": "Certifications",
-    "licenses": "Certifications",
-    "licences": "Certifications",
-    "hobby": "Hobby",
-    "hobbies": "Hobby",
-    "interests": "Hobby",
-}
-
 CV_ANONYMIZATION_PROMPT_TEMPLATE = """You anonymize and format CV content for PDF export.
+
+Critical source-of-truth rule:
+- After this PDF text has been converted to plain text, you are the only component allowed to classify CV content into sections.
+- All section classification must be based only on the converted CV text below.
+- Do not use assumptions.
+- Do not infer content outside the given CV text.
+- Do not invent information.
 
 Privacy rules:
 - Keep only the candidate first/given name; remove surnames/family names.
@@ -58,15 +31,26 @@ Privacy rules:
 - Remove house numbers.
 - Remove postal codes.
 - Keep only the city from any address, for example "Via Roma 10, 6900 Lugano, Switzerland" becomes "Lugano".
+- Preserve professional information while anonymizing personal identifying data.
 - Preserve all non-sensitive professional information: professional summary, experience, job titles, employers, dates, responsibilities, achievements, education, skills, certifications, languages, projects, technical competencies, and hobbies.
 - Anonymize personal/sensitive data only. Do not remove professional content unless it contains personal identifying data.
-- Never invent missing information.
 
 Classification rules:
-- Classify all CV content into the most appropriate required section.
-- Treat alternative headings such as "Work History" as Experience, "Academic Background" as Education, "Technical Skills" as Skills, and "Interests" as Hobby.
+- Classify all CV content into the most appropriate required section yourself, using only the converted CV text.
+- Always classify content into these exact sections in this exact order:
+  1. Personal data
+  2. Experience
+  3. Education
+  4. Skills
+  5. Certifications
+  6. Hobby
+- Skills may appear under headings such as Core Competencies, Technical Skills, Stack, Technologies, Tools, Frameworks, Methodologies, or inside experience descriptions.
+- If skill-related information exists anywhere in the CV text, the Skills section must contain it.
 - Keep certifications and licenses in Certifications, not Education or Skills.
 - Keep hobbies, interests, and extracurricular non-professional activities in Hobby.
+- Do not invent information.
+- Do not use assumptions.
+- Do not infer content outside the given CV text.
 
 Formatting rules:
 - You must output exactly these sections and in this order:
@@ -76,6 +60,9 @@ Formatting rules:
   4. Skills
   5. Certifications
   6. Hobby
+- Never omit a section heading.
+- Never leave a section empty.
+- If no information is available for a section, write `Not specified`.
 - Never drop a section heading. Do not duplicate section headings.
 - Section titles must be bold in the exported PDF. Mark each section title with markdown bold delimiters, for example **Personal data**, so the renderer can draw real bold text without showing the delimiters.
 - Use only round bullet points for lists; never use square bullet points.
@@ -107,26 +94,21 @@ async def anonymize_cv_text(cv_text: str) -> str:
 
 
 def normalize_cv_sections(anonymized_text: str) -> str:
-    """Return anonymized CV text with one complete, ordered section set."""
+    """Return Ollama-provided CV sections once, ordered, and structurally complete."""
     section_content = {section: [] for section in REQUIRED_CV_SECTIONS}
     current_section: str | None = None
-    preamble: list[str] = []
 
     for raw_line in anonymized_text.splitlines():
         line = raw_line.strip()
         if not line:
             continue
-        section = _section_from_heading(line)
-        if section:
+        section = _required_section_heading(line)
+        if section is not None:
             current_section = section
             continue
         if current_section is None:
-            preamble.append(_normalize_content_line(line))
             continue
         section_content[current_section].append(_normalize_content_line(line))
-
-    if preamble:
-        section_content["Personal data"] = preamble + section_content["Personal data"]
 
     normalized_lines: list[str] = []
     for section in REQUIRED_CV_SECTIONS:
@@ -134,7 +116,7 @@ def normalize_cv_sections(anonymized_text: str) -> str:
             normalized_lines.append("")
         normalized_lines.append(f"**{section}**")
         content = _dedupe_content(section_content[section])
-        if not content:
+        if not content or _content_is_empty(content):
             normalized_lines.append("• Not specified")
             continue
         normalized_lines.extend(content)
@@ -142,26 +124,35 @@ def normalize_cv_sections(anonymized_text: str) -> str:
     return "\n".join(normalized_lines)
 
 
-def _section_from_heading(line: str) -> str | None:
+def _required_section_heading(line: str) -> str | None:
     normalized = _normalize_heading_text(line)
-    return _SECTION_ALIASES.get(normalized)
+    for section in REQUIRED_CV_SECTIONS:
+        if normalized == section.casefold():
+            return section
+    return None
 
 
 def _normalize_heading_text(line: str) -> str:
     heading = line.strip()
-    heading = re.sub(r"\*\*([^*]+)\*\*", r"\1", heading).strip()
-    heading = heading.strip("#:")
-    heading = re.sub(r"^[-*•▪■□\s]+", "", heading).strip()
-    heading = heading.rstrip(":").strip()
-    return re.sub(r"\s+", " ", heading).casefold()
+    if heading.startswith("**") and heading.endswith("**") and len(heading) > 4:
+        heading = heading[2:-2].strip()
+    heading = heading.strip("#:").strip().removesuffix(":").strip()
+    return " ".join(heading.split()).casefold()
 
 
 def _normalize_content_line(line: str) -> str:
-    text = re.sub(r"^[▪■□]\s*", "• ", line.strip())
-    text = re.sub(r"^[-*]\s+", "• ", text)
+    text = line.strip()
+    if text.startswith(("▪", "■", "□")):
+        text = f"• {text[1:].strip()}"
+    elif text.startswith(("- ", "* ")):
+        text = f"• {text[2:].strip()}"
     if not text.startswith("•"):
         return f"• {text}"
-    return re.sub(r"^•\s*", "• ", text)
+    return f"• {text[1:].strip()}"
+
+
+def _content_is_empty(lines: list[str]) -> bool:
+    return all(line.removeprefix("•").strip() == "" for line in lines)
 
 
 def _dedupe_content(lines: list[str]) -> list[str]:

--- a/src/services/cv_pdf_rendering.py
+++ b/src/services/cv_pdf_rendering.py
@@ -62,6 +62,7 @@ def render_anonymized_cv_pdf(
         logger.debug("CV PDF final output page count before saving: %s", final_output_page_count)
         with output_path.open("wb") as output_file:
             writer.write(output_file)
+        _validate_pdf_has_no_duplicated_pages(output_path)
         return output_path
     except ToolError:
         raise
@@ -199,3 +200,22 @@ def _round_bullet_text(line: str) -> str | None:
     if not stripped_line or stripped_line[0] != ROUND_BULLET:
         return None
     return stripped_line[1:].strip()
+
+
+def _validate_pdf_has_no_duplicated_pages(pdf_path: Path) -> None:
+    """Reject generated PDFs that contain duplicate non-empty extracted page text."""
+    from pypdf import PdfReader
+
+    reader = PdfReader(str(pdf_path))
+    seen_pages: dict[str, int] = {}
+    for page_index, page in enumerate(reader.pages, start=1):
+        page_text = " ".join((page.extract_text() or "").split())
+        if not page_text:
+            continue
+        first_seen_page = seen_pages.get(page_text)
+        if first_seen_page is not None:
+            raise ToolError(
+                "Generated anonymized CV PDF contains duplicated page content "
+                f"on pages {first_seen_page} and {page_index}."
+            )
+        seen_pages[page_text] = page_index

--- a/tests/unit/test_cv_export.py
+++ b/tests/unit/test_cv_export.py
@@ -182,28 +182,72 @@ def test_normalize_cv_sections_restores_missing_sections() -> None:
     assert result.count("• Not specified") == 3
 
 
-def test_normalize_cv_sections_maps_alternative_section_titles() -> None:
+def test_normalize_cv_sections_does_not_assign_alternative_headings_after_ollama() -> None:
     result = cv_anonymization.normalize_cv_sections(
         "Contact\n"
         "• Ada\n"
         "Work History\n"
         "• Platform Engineer\n"
-        "Academic Background\n"
-        "• BSc Informatics\n"
         "Technical Skills\n"
-        "• Python\n"
-        "Certificates\n"
-        "• Kubernetes Administrator\n"
-        "Interests\n"
-        "• Climbing"
+        "• Python"
     )
 
     assert [line for line in result.splitlines() if line.startswith("**")] == EXPECTED_SECTION_HEADINGS
-    assert result.index("• Platform Engineer") < result.index("**Education**")
-    assert "• BSc Informatics" in result
+    assert "• Ada" not in result
+    assert "• Platform Engineer" not in result
+    assert "• Python" not in result
+    assert result.count("• Not specified") == 6
+
+
+def test_normalize_cv_sections_keeps_skills_when_ollama_returns_skill_content() -> None:
+    result = cv_anonymization.normalize_cv_sections(
+        "**Personal data**\n"
+        "• Ada\n"
+        "**Skills**\n"
+        "• Python, FastAPI, Docker"
+    )
+
+    assert "**Skills**\n• Python, FastAPI, Docker" in result
+
+
+def test_normalize_cv_sections_replaces_empty_sections_with_not_specified() -> None:
+    result = cv_anonymization.normalize_cv_sections(
+        "**Personal data**\n"
+        "**Experience**\n"
+        "•   \n"
+        "**Skills**\n"
+        "• Python"
+    )
+
+    assert "**Personal data**\n• Not specified" in result
+    assert "**Experience**\n• Not specified" in result
+    assert "**Skills**\n• Python" in result
+
+
+def test_normalize_cv_sections_outputs_all_sections_exactly_once() -> None:
+    result = cv_anonymization.normalize_cv_sections(
+        "**Skills**\n"
+        "• Python\n"
+        "**Skills**\n"
+        "• FastAPI\n"
+        "**Experience**\n"
+        "• Developer"
+    )
+
+    assert [line for line in result.splitlines() if line.startswith("**")] == EXPECTED_SECTION_HEADINGS
+    for heading in EXPECTED_SECTION_HEADINGS:
+        assert result.count(heading) == 1
     assert "• Python" in result
-    assert "• Kubernetes Administrator" in result
-    assert "• Climbing" in result
+    assert "• FastAPI" in result
+
+
+def test_cv_anonymization_has_no_regex_or_keyword_section_extraction() -> None:
+    source = Path(cv_anonymization.__file__).read_text()
+
+    assert "import re" not in source
+    assert "_SECTION_ALIASES" not in source
+    for forbidden in ("Core Competencies", "Technical Skills", "Stack", "Technologies", "Tools", "Frameworks", "Methodologies"):
+        assert forbidden not in source.replace(cv_anonymization.CV_ANONYMIZATION_PROMPT_TEMPLATE, "")
 
 
 def test_anonymize_cv_text_rejects_empty_ollama_response(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -235,6 +279,9 @@ def test_render_anonymized_cv_pdf_writes_output_with_template(monkeypatch: pytes
 
         def merge_page(self, other: object) -> None:
             self.other = other
+
+        def extract_text(self) -> str:
+            return "M. R. Engineer"
 
     class FakeReader:
         def __init__(self, path: str) -> None:
@@ -303,6 +350,22 @@ def test_render_anonymized_cv_pdf_one_page_cv_is_rendered_once(tmp_path: Path) -
     assert full_text.count("Experience") == 1
     assert full_text.count("Senior Developer") == 1
     assert full_text.count("Skills") == 1
+
+
+
+
+def test_validate_pdf_has_no_duplicated_pages_rejects_identical_page_text(tmp_path: Path) -> None:
+    from reportlab.pdfgen import canvas
+
+    duplicate_pdf = tmp_path / "duplicate-pages.pdf"
+    pdf = canvas.Canvas(str(duplicate_pdf), pagesize=(595, 842))
+    for _ in range(2):
+        pdf.drawString(72, 720, "Repeated anonymized CV page")
+        pdf.showPage()
+    pdf.save()
+
+    with pytest.raises(ToolError, match="duplicated page content"):
+        cv_pdf_rendering._validate_pdf_has_no_duplicated_pages(duplicate_pdf)
 
 
 def test_anonymized_cv_endpoint_anonymizes_once_and_renders_once(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
### Motivation
- Ensure the Ollama model is the sole source of truth for classifying converted CV text into sections and stop any code-side heuristics from inventing or inferring content.
- Fix duplicated pages being produced in the anonymized PDF output.
- Make sure Skills and other sections are preserved when the model returns content and that missing sections are handled predictably.

### Description
- Strengthened the Ollama prompt in `src/services/cv_anonymization.py` to explicitly require the model to classify all CV content into the six sections in the exact order and to never omit or leave a section empty, with a `Not specified` fallback if no info is present. 
- Removed in-code heuristics/aliases for heading assignment and changed post-processing in `normalize_cv_sections` to only validate and normalize the model-provided structure (no regex/keyword-based extraction or reassignment of lines to sections). 
- Added `_content_is_empty` helper and stricter normalization to treat truly empty model-provided sections as `Not specified` while deduping content. 
- Added duplicate-page validation in `src/services/cv_pdf_rendering.py` via `_validate_pdf_has_no_duplicated_pages` and invoked it after the final PDF is written to ensure no two non-empty pages contain identical extracted text. 
- Added and updated unit tests in `tests/unit/test_cv_export.py` to cover: exact once occurrence of all six headings, Skills preservation when Ollama returns skill content, empty-section -> `Not specified` replacement, rejection of duplicated PDF pages, and an assertion that no regex/keyword-based post-Ollama section extraction exists in the codebase.

### Testing
- Ran `PYTHONPATH=src python -m compileall src` which completed successfully. 
- Ran `PYTHONPATH=src pytest -q` and all tests passed: `86 passed` (two deprecation warnings from third-party packages were observed but unrelated to these fixes). 
- New/updated unit tests exercised `normalize_cv_sections`, `anonymize_cv_text` prompt behavior, and `_validate_pdf_has_no_duplicated_pages`, and they succeeded under the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a4645ce648328a8024b21c93d7a1a)