### PR TITLE
fix: preserve CV anonymization detail

### DIFF
--- a/src/services/cv_anonymization.py
+++ b/src/services/cv_anonymization.py
@@ -15,6 +15,11 @@ REQUIRED_CV_SECTIONS = (
 
 CV_ANONYMIZATION_PROMPT_TEMPLATE = """You anonymize and format CV content for PDF export.
 
+Primary objective:
+- This workflow must not rewrite, shorten, summarize, evaluate relevance, or remove professional content.
+- Your only tasks are to anonymize private/personal identifying data and reorganize the remaining CV text into the required sections.
+- Preserve as much original professional information as possible, including the original level of detail and bullet granularity.
+
 Critical source-of-truth rule:
 - After this PDF text has been converted to plain text, you are the only component allowed to classify CV content into sections.
 - All section classification must be based only on the converted CV text below.
@@ -23,17 +28,19 @@ Critical source-of-truth rule:
 - Do not invent information.
 
 Privacy rules:
-- Keep only the candidate first/given name; remove surnames/family names.
+- Only anonymize personal identifying data such as name, email, phone, LinkedIn, address, precise personal location, and other private identifiers.
+- Keep only the candidate first/given name when a name is present; remove surnames/family names.
 - Remove phone numbers.
 - Remove email addresses.
+- Remove LinkedIn and personal profile URLs.
 - Remove street addresses.
 - Remove street names.
 - Remove house numbers.
 - Remove postal codes.
 - Keep only the city from any address, for example "Via Roma 10, 6900 Lugano, Switzerland" becomes "Lugano".
-- Preserve professional information while anonymizing personal identifying data.
-- Preserve all non-sensitive professional information: professional summary, experience, job titles, employers, dates, responsibilities, achievements, education, skills, certifications, languages, projects, technical competencies, and hobbies.
-- Anonymize personal/sensitive data only. Do not remove professional content unless it contains personal identifying data.
+- Company names, client names, technologies, project descriptions, dates, roles, education, and professional achievements must be preserved unless the application explicitly requires them to be anonymized.
+- Preserve all non-sensitive professional information: professional summary, all work experiences, projects, responsibilities, achievements, teaching/training activities, technical stacks, education, skills, certifications, languages, technical competencies, and hobbies.
+- Anonymize personal/sensitive data only. Do not remove professional content unless that exact content contains personal identifying data.
 
 Classification rules:
 - Classify all CV content into the most appropriate required section yourself, using only the converted CV text.
@@ -46,11 +53,24 @@ Classification rules:
   6. Hobby
 - Skills may appear under headings such as Core Competencies, Technical Skills, Stack, Technologies, Tools, Frameworks, Methodologies, or inside experience descriptions.
 - If skill-related information exists anywhere in the CV text, the Skills section must contain it.
+- If information belongs to skills, place it in Skills.
+- If information belongs to experience, place it in Experience.
+- If information belongs to education, place it in Education.
 - Keep certifications and licenses in Certifications, not Education or Skills.
 - Keep hobbies, interests, and extracurricular non-professional activities in Hobby.
 - Do not invent information.
 - Do not use assumptions.
 - Do not infer content outside the given CV text.
+
+Professional preservation rules:
+- Do not summarize the CV.
+- Do not shorten the CV.
+- Do not remove professional information.
+- Do not judge whether an experience is relevant or not.
+- Do not delete jobs, projects, bullet points, skills, education, training, languages, or technical stacks unless the specific text contains private data.
+- Keep all work experiences, projects, responsibilities, achievements, teaching/training activities, technical stacks, education, languages, and skills.
+- Preserve detailed bullet points instead of replacing them with short summaries.
+- Keep technical skills from Core Competencies, Technical Skills, Stack, Technologies, Tools, Frameworks, Methodologies, and similar source lines.
 
 Formatting rules:
 - You must output exactly these sections and in this order:
@@ -73,6 +93,7 @@ Output rules:
 - Return only the formatted anonymized CV content.
 - Do not start with an introductory sentence such as "Here is the anonymized CV content for PDF export:".
 - Do not add introductions, explanations, comments, notes, markdown fences, or extra text.
+- Do not write comments such as "I removed this section because..." or any explanation of removed content.
 
 CV content:
 {cv_text}
@@ -115,7 +136,7 @@ def normalize_cv_sections(anonymized_text: str) -> str:
         if normalized_lines:
             normalized_lines.append("")
         normalized_lines.append(f"**{section}**")
-        content = _dedupe_content(section_content[section])
+        content = section_content[section]
         if not content or _content_is_empty(content):
             normalized_lines.append("• Not specified")
             continue
@@ -153,18 +174,6 @@ def _normalize_content_line(line: str) -> str:
 
 def _content_is_empty(lines: list[str]) -> bool:
     return all(line.removeprefix("•").strip() == "" for line in lines)
-
-
-def _dedupe_content(lines: list[str]) -> list[str]:
-    seen: set[str] = set()
-    deduped: list[str] = []
-    for line in lines:
-        key = line.casefold()
-        if key in seen:
-            continue
-        seen.add(key)
-        deduped.append(line)
-    return deduped
 
 
 def _remove_introductory_sentence(anonymized_text: str) -> str:

--- a/tests/unit/test_cv_export.py
+++ b/tests/unit/test_cv_export.py
@@ -113,6 +113,68 @@ def test_anonymize_cv_text_uses_ollama_prompt(monkeypatch: pytest.MonkeyPatch) -
     assert "never use square bullet points" in captured["prompt"]
     assert "Return only the formatted anonymized CV content" in captured["prompt"]
     assert "Do not start with an introductory sentence" in captured["prompt"]
+    assert "Do not summarize the CV" in captured["prompt"]
+    assert "Do not shorten the CV" in captured["prompt"]
+    assert "Do not remove professional information" in captured["prompt"]
+    assert "Do not judge whether an experience is relevant or not" in captured["prompt"]
+    assert "Preserve detailed bullet points instead of replacing them with short summaries" in captured["prompt"]
+    assert "Company names, client names, technologies, project descriptions, dates, roles, education, and professional achievements must be preserved" in captured["prompt"]
+    assert "Do not write comments such as" in captured["prompt"]
+
+
+def test_anonymize_cv_text_preserves_professional_entries_and_detail(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_chat_with_ollama(prompt: str, **_: object) -> str:
+        assert "Senior Developer at ExampleBank" in prompt
+        assert "Teaching Assistant at Example University" in prompt
+        return (
+            "**Personal data**\n"
+            "• Lugano\n"
+            "**Experience**\n"
+            "• Senior Developer at ExampleBank — 2021-2024\n"
+            "• Built payment APIs with Python, FastAPI, PostgreSQL, Docker, and Kubernetes.\n"
+            "• Led migration of legacy batch jobs to asynchronous services and reduced processing time.\n"
+            "• Teaching Assistant at Example University — 2019-2020\n"
+            "• Delivered Python labs, reviewed assignments, and supported student projects.\n"
+            "**Education**\n"
+            "• MSc Computer Science — Example University — 2020\n"
+            "**Skills**\n"
+            "• Core Competencies: architecture, mentoring, stakeholder management\n"
+            "• Technical Skills: Python, FastAPI, PostgreSQL, Docker, Kubernetes\n"
+            "• Stack: Linux, Git, CI/CD, REST APIs\n"
+            "**Certifications**\n"
+            "• Not specified\n"
+            "**Hobby**\n"
+            "• Not specified"
+        )
+
+    monkeypatch.setattr(cv_anonymization, "chat_with_ollama", fake_chat_with_ollama)
+
+    result = asyncio.run(
+        cv_anonymization.anonymize_cv_text(
+            "Mario Rossi\n"
+            "Senior Developer at ExampleBank — 2021-2024\n"
+            "Built payment APIs with Python, FastAPI, PostgreSQL, Docker, and Kubernetes.\n"
+            "Led migration of legacy batch jobs to asynchronous services and reduced processing time.\n"
+            "Teaching Assistant at Example University — 2019-2020\n"
+            "Delivered Python labs, reviewed assignments, and supported student projects.\n"
+            "MSc Computer Science — Example University — 2020\n"
+            "Core Competencies: architecture, mentoring, stakeholder management\n"
+            "Technical Skills: Python, FastAPI, PostgreSQL, Docker, Kubernetes\n"
+            "Stack: Linux, Git, CI/CD, REST APIs"
+        )
+    )
+
+    assert "Senior Developer at ExampleBank" in result
+    assert "Teaching Assistant at Example University" in result
+    assert "Built payment APIs with Python, FastAPI, PostgreSQL, Docker, and Kubernetes." in result
+    assert "Led migration of legacy batch jobs to asynchronous services and reduced processing time." in result
+    assert "Delivered Python labs, reviewed assignments, and supported student projects." in result
+    assert "Core Competencies: architecture, mentoring, stakeholder management" in result
+    assert "Technical Skills: Python, FastAPI, PostgreSQL, Docker, Kubernetes" in result
+    assert "Stack: Linux, Git, CI/CD, REST APIs" in result
+    assert "removed this section because" not in result.lower()
+    for heading in EXPECTED_SECTION_HEADINGS:
+        assert result.count(heading) == 1
 
 
 def test_anonymize_cv_text_removes_introductory_sentence(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -239,6 +301,16 @@ def test_normalize_cv_sections_outputs_all_sections_exactly_once() -> None:
         assert result.count(heading) == 1
     assert "• Python" in result
     assert "• FastAPI" in result
+
+
+def test_normalize_cv_sections_does_not_dedupe_repeated_professional_content() -> None:
+    result = cv_anonymization.normalize_cv_sections(
+        "**Experience**\n"
+        "• Built REST APIs\n"
+        "• Built REST APIs"
+    )
+
+    assert result.count("• Built REST APIs") == 2
 
 
 def test_cv_anonymization_has_no_regex_or_keyword_section_extraction() -> None:
@@ -574,3 +646,26 @@ def test_write_text_overlay_multipage_continues_instead_of_repeating_page_one(tm
     assert combined_text.count("Skills") == 1
     assert combined_text.count("Certifications") == 1
     assert combined_text.index("Skills") < combined_text.index("Certifications")
+
+
+def test_render_anonymized_cv_pdf_rejects_accidentally_duplicated_pages(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    output_path = tmp_path / "duplicated-output.pdf"
+
+    def fake_write_text_overlay(text: str, overlay_path: Path, width: float, height: float) -> None:
+        from reportlab.pdfgen import canvas
+
+        pdf = canvas.Canvas(str(overlay_path), pagesize=(width, height))
+        for _ in range(2):
+            pdf.drawString(72, 720, "Repeated rendered CV content")
+            pdf.showPage()
+        pdf.save()
+
+    monkeypatch.setattr(cv_pdf_rendering, "_write_text_overlay", fake_write_text_overlay)
+
+    with pytest.raises(ToolError, match="duplicated page content"):
+        cv_pdf_rendering.render_anonymized_cv_pdf(
+            "**Experience**\n• Repeated rendered CV content",
+            output_path,
+        )


### PR DESCRIPTION
### Motivation
- The Ollama-based CV anonymization was producing overly summarized outputs and removing professional detail instead of only anonymizing personal identifiers and reorganizing content.
- Post-processing was deduplicating lines which could remove legitimate repeated professional bullets.
- The PDF generation must detect accidentally duplicated pages to prevent repeated content in the final PDF.

### Description
- Strengthen the Ollama prompt in `src/services/cv_anonymization.py` to explicitly instruct the model to only anonymize personal identifiers, preserve all professional information and detail, not summarize/shorten/judge relevance, and output the six required sections in the exact order (`Personal data`, `Experience`, `Education`, `Skills`, `Certifications`, `Hobby`).
- Add explicit placement guidance that skill/experience/education content must be moved to the corresponding sections by the model.
- Stop deduplication in post-processing by removing the `_dedupe_content` step so `normalize_cv_sections` preserves repeated professional lines exactly as the model returned them.
- Add regression tests in `tests/unit/test_cv_export.py` to assert prompt content, preservation of professional entries and bullet detail, that repeated professional lines are not deduped, and that accidentally duplicated PDF pages are rejected.

### Testing
- Ran unit tests for the CV export module with `PYTHONPATH=src pytest -q tests/unit/test_cv_export.py` which passed (27 passed, 4 warnings).
- Compiled the package and ran the full test suite with `python -m compileall src && PYTHONPATH=src pytest -q` which passed (89 passed, 4 warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a4b2f68fc832896cce0bc1ef762c1)