### PR TITLE
fix: validate CV overlay pages before template merge

### DIFF
--- a/src/services/cv_pdf_rendering.py
+++ b/src/services/cv_pdf_rendering.py
@@ -48,6 +48,7 @@ def render_anonymized_cv_pdf(
         logger.debug("CV PDF generated content page count: %s", len(overlay_pages))
         if not overlay_pages:
             raise ToolError("Generated anonymized CV overlay does not contain any pages.")
+        _validate_pdf_has_no_duplicated_pages(overlay_path)
 
         writer = PdfWriter()
         for page_number, overlay_page in enumerate(overlay_pages, start=1):
@@ -62,7 +63,6 @@ def render_anonymized_cv_pdf(
         logger.debug("CV PDF final output page count before saving: %s", final_output_page_count)
         with output_path.open("wb") as output_file:
             writer.write(output_file)
-        _validate_pdf_has_no_duplicated_pages(output_path)
         return output_path
     except ToolError:
         raise
@@ -210,7 +210,13 @@ def _validate_pdf_has_no_duplicated_pages(pdf_path: Path) -> None:
     seen_pages: dict[str, int] = {}
     for page_index, page in enumerate(reader.pages, start=1):
         page_text = " ".join((page.extract_text() or "").split())
-        if not page_text:
+        logger.debug(
+            "PDF duplicate-page validation page %s: extracted text length=%s, preview=%r",
+            page_index,
+            len(page_text),
+            page_text[:200],
+        )
+        if len(page_text) < 100:
             continue
         first_seen_page = seen_pages.get(page_text)
         if first_seen_page is not None:

--- a/tests/unit/test_cv_export.py
+++ b/tests/unit/test_cv_export.py
@@ -515,8 +515,9 @@ def test_validate_pdf_has_no_duplicated_pages_rejects_identical_page_text(tmp_pa
 
     duplicate_pdf = tmp_path / "duplicate-pages.pdf"
     pdf = canvas.Canvas(str(duplicate_pdf), pagesize=(595, 842))
+    repeated_text = "Repeated anonymized CV page " * 8
     for _ in range(2):
-        pdf.drawString(72, 720, "Repeated anonymized CV page")
+        pdf.drawString(72, 720, repeated_text)
         pdf.showPage()
     pdf.save()
 
@@ -732,6 +733,45 @@ def test_write_text_overlay_multipage_continues_instead_of_repeating_page_one(tm
     assert combined_text.index("Skills") < combined_text.index("Certifications")
 
 
+
+def test_render_anonymized_cv_pdf_validates_overlay_before_merging_template(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from reportlab.pdfgen import canvas
+
+    template_path = tmp_path / "template.pdf"
+    template = canvas.Canvas(str(template_path), pagesize=(595, 842))
+    template.drawString(72, 800, "ReleWant letterhead repeated on every rendered page " * 4)
+    template.save()
+    output_path = tmp_path / "letterhead-output.pdf"
+    validated_paths: list[Path] = []
+
+    def fake_write_text_overlay(text: str, overlay_path: Path, width: float, height: float) -> None:
+        pdf = canvas.Canvas(str(overlay_path), pagesize=(width, height))
+        pdf.drawString(72, 720, "First generated CV content page with unique experience details.")
+        pdf.showPage()
+        pdf.drawString(72, 720, "Second generated CV content page with unique education details.")
+        pdf.showPage()
+        pdf.save()
+
+    original_validate = cv_pdf_rendering._validate_pdf_has_no_duplicated_pages
+
+    def spy_validate(pdf_path: Path) -> None:
+        validated_paths.append(pdf_path)
+        original_validate(pdf_path)
+
+    monkeypatch.setattr(cv_pdf_rendering, "_write_text_overlay", fake_write_text_overlay)
+    monkeypatch.setattr(cv_pdf_rendering, "_validate_pdf_has_no_duplicated_pages", spy_validate)
+
+    cv_pdf_rendering.render_anonymized_cv_pdf(
+        "**Experience**\n• Generated content",
+        output_path,
+        template_path=template_path,
+    )
+
+    assert output_path.exists()
+    assert validated_paths == [output_path.with_suffix(".overlay.pdf")]
+
 def test_render_anonymized_cv_pdf_rejects_accidentally_duplicated_pages(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -741,8 +781,9 @@ def test_render_anonymized_cv_pdf_rejects_accidentally_duplicated_pages(
         from reportlab.pdfgen import canvas
 
         pdf = canvas.Canvas(str(overlay_path), pagesize=(width, height))
+        repeated_text = "Repeated rendered CV content " * 8
         for _ in range(2):
-            pdf.drawString(72, 720, "Repeated rendered CV content")
+            pdf.drawString(72, 720, repeated_text)
             pdf.showPage()
         pdf.save()
 


### PR DESCRIPTION
### Motivation
- Prevent false duplicated-page errors caused by the shared ReleWant letterhead template being present on every merged output page.
- Ensure duplicate detection targets only generated CV content (the overlay) rather than the final pages that include identical template text.

### Description
- In `render_anonymized_cv_pdf()` move duplicate-page validation to immediately after generating the overlay by calling `_validate_pdf_has_no_duplicated_pages(overlay_path)` before creating the `PdfWriter` and merging with the template.
- Remove the final call to `_validate_pdf_has_no_duplicated_pages(output_path)` after writing the merged PDF.
- Keep the merge logic unchanged: each overlay page is still merged onto a fresh `copy.deepcopy(template_reader.pages[0])` and added to the writer.
- Enhance `_validate_pdf_has_no_duplicated_pages()` with debug logging that shows the page number, extracted text length, and the first 200 characters of extracted text, and ignore pages with very short extracted text (fewer than 100 characters).
- Add a regression test `test_render_anonymized_cv_pdf_validates_overlay_before_merging_template` and update duplicate-page tests to ensure real duplicated overlay pages are still detected while repeated template letterhead does not trigger a false positive.

### Testing
- Ran `python -m compileall src` which succeeded.
- Ran overlay-only tests with `PYTHONPATH=src pytest tests/unit/test_cv_export.py -q`, which passed (`30 passed, 4 warnings`).
- Ran the full test suite with `pytest -q`, which passed (`92 passed, 4 warnings`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a56d981208328bbe1f52ddad55795)