### PR TITLE
fix: omit empty CV anonymization sections

### DIFF
--- a/src/services/cv_anonymization.py
+++ b/src/services/cv_anonymization.py
@@ -28,7 +28,7 @@ NOT_SPECIFIED = "Not specified"
 
 CV_ANONYMIZATION_PROMPT_TEMPLATE = """You anonymize CV content for PDF export and return structured JSON only.
 
-Return only valid JSON with exactly this schema and these six keys:
+Return only valid JSON using only these CV section keys:
 {{
   "anagraphical_data": [],
   "experience": [],
@@ -55,8 +55,8 @@ Classification and preservation rules:
 - Do not summarize professional content.
 - Do not remove professional experience, education, skills, certifications, languages, projects, technical competencies, hobbies, or professional summary.
 - Put languages, projects, technical competencies, and professional summary in the most appropriate array.
-- If a field has no content, return ["Not specified"].
-- Every value must be a non-empty array of strings.
+- If a field has no content in the source CV, omit that field or return an empty array.
+- Every included field must be an array of non-empty strings.
 
 Output rules:
 - Return only JSON.
@@ -68,7 +68,7 @@ CV content:
 
 CV_JSON_REPAIR_PROMPT_TEMPLATE = """Repair this anonymized CV response into valid JSON only.
 
-It must have exactly these six keys, each with a non-empty array of strings:
+It must use only these CV section keys, each with an array of strings:
 - anagraphical_data
 - experience
 - education
@@ -76,7 +76,7 @@ It must have exactly these six keys, each with a non-empty array of strings:
 - certifications
 - hobby
 
-If a field has no content, use ["Not specified"]. Preserve all professional content from the source CV. Continue applying privacy rules: keep only first/given name; remove surnames, phone numbers, emails, URLs, street names, house numbers, and postal codes; keep only city from addresses.
+If a field has no content in the source CV, omit that field or use an empty array. Preserve all professional content from the source CV. Continue applying privacy rules: keep only first/given name; remove surnames, phone numbers, emails, URLs, street names, house numbers, and postal codes; keep only city from addresses.
 
 Source CV content:
 {cv_text}
@@ -88,7 +88,6 @@ Invalid response:
 OLLAMA_JSON_FORMAT = {
     "type": "object",
     "properties": {key: {"type": "array", "items": {"type": "string"}} for key in REQUIRED_CV_JSON_KEYS},
-    "required": list(REQUIRED_CV_JSON_KEYS),
 }
 
 
@@ -131,18 +130,17 @@ def _parse_and_validate_cv_json(response: str, source_cv_text: str) -> dict[str,
         raise ToolError("Ollama returned anonymized CV JSON with an unexpected shape.")
 
     extra_keys = set(parsed) - set(REQUIRED_CV_JSON_KEYS)
-    missing_keys = [key for key in REQUIRED_CV_JSON_KEYS if key not in parsed]
-    if missing_keys or extra_keys:
-        raise ToolError("Ollama anonymized CV JSON must contain exactly the required CV sections.")
+    if extra_keys:
+        raise ToolError("Ollama anonymized CV JSON contains unexpected CV sections.")
 
     validated: dict[str, list[str]] = {}
     for key in REQUIRED_CV_JSON_KEYS:
-        value = parsed[key]
-        if not isinstance(value, list) or not value:
-            raise ToolError(f"Ollama anonymized CV JSON field '{key}' must be a non-empty list.")
+        value = parsed.get(key, [])
+        if not isinstance(value, list):
+            raise ToolError(f"Ollama anonymized CV JSON field '{key}' must be a list when provided.")
         if not all(isinstance(item, str) and item.strip() for item in value):
             raise ToolError(f"Ollama anonymized CV JSON field '{key}' must contain only non-empty strings.")
-        validated[key] = [item.strip() for item in value]
+        validated[key] = [item.strip() for item in value if not _is_not_specified_value(item)]
 
     _validate_source_aware_sections(validated, source_cv_text)
     return validated
@@ -176,12 +174,18 @@ def _matches_any(text: str, patterns: tuple[str, ...]) -> bool:
 
 
 def _is_not_specified_only(items: list[str]) -> bool:
-    return len(items) == 1 and items[0].strip().casefold() == NOT_SPECIFIED.casefold()
+    return not items or (len(items) == 1 and _is_not_specified_value(items[0]))
+
+
+def _is_not_specified_value(item: str) -> bool:
+    return item.strip().casefold() == NOT_SPECIFIED.casefold()
 
 
 def _format_cv_json_as_text(cv_json: dict[str, list[str]]) -> str:
     sections: list[str] = []
     for key in REQUIRED_CV_JSON_KEYS:
+        if not cv_json[key]:
+            continue
         lines = [f"**{SECTION_TITLES[key]}**"]
         lines.extend(f"• {item}" for item in cv_json[key])
         sections.append("\n".join(lines))

--- a/tests/unit/test_cv_export.py
+++ b/tests/unit/test_cv_export.py
@@ -66,15 +66,7 @@ def test_anonymize_cv_text_uses_ollama_prompt(monkeypatch: pytest.MonkeyPatch) -
         "• Gabriele\n"
         "• Lugano\n\n"
         "**Experience**\n"
-        "• Senior Developer\n\n"
-        "**Education**\n"
-        "• Not specified\n\n"
-        "**Skills**\n"
-        "• Not specified\n\n"
-        "**Certifications**\n"
-        "• Not specified\n\n"
-        "**Hobby**\n"
-        "• Not specified"
+        "• Senior Developer"
     )
     assert "Keep only the candidate first/given name" in captured["prompt"]
     assert "Remove phone numbers" in captured["prompt"]
@@ -432,7 +424,7 @@ def test_cv_json_with_education_must_not_return_not_specified() -> None:
         cv_anonymization._parse_and_validate_cv_json(response, "Education: Bachelor degree at University")
 
 
-def test_anonymize_cv_text_formats_valid_json_and_defaults_missing_hobby(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_anonymize_cv_text_formats_valid_json_and_omits_missing_sections(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_chat_with_ollama(prompt: str, **kwargs: object) -> str:
         assert kwargs["response_format"] == cv_anonymization.OLLAMA_JSON_FORMAT
         assert kwargs["options"] == {"temperature": 0}
@@ -442,10 +434,28 @@ def test_anonymize_cv_text_formats_valid_json_and_defaults_missing_hobby(monkeyp
 
     result = asyncio.run(cv_anonymization.anonymize_cv_text("Experience: Senior Developer\nEducation: University\nSkills: Python"))
 
-    for section in ("Anagraphical data", "Experience", "Education", "Skills", "Certifications", "Hobby"):
+    for section in ("Anagraphical data", "Experience", "Education", "Skills"):
         assert result.count(f"**{section}**") == 1
-    assert "• Not specified" in result
+    assert "**Certifications**" not in result
+    assert "**Hobby**" not in result
+    assert "• Not specified" not in result
     assert "• Senior Developer" in result
+
+
+def test_anonymize_cv_text_allows_omitted_and_empty_missing_sections(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_chat_with_ollama(prompt: str, **_: object) -> str:
+        return '{"anagraphical_data":["Gabriele"],"experience":["Developer"],"hobby":[]}'
+
+    monkeypatch.setattr(cv_anonymization, "chat_with_ollama", fake_chat_with_ollama)
+
+    result = asyncio.run(cv_anonymization.anonymize_cv_text("Gabriele\nExperience: Developer"))
+
+    assert "**Anagraphical data**" in result
+    assert "**Experience**" in result
+    assert "**Education**" not in result
+    assert "**Skills**" not in result
+    assert "**Certifications**" not in result
+    assert "**Hobby**" not in result
 
 
 def test_anonymize_cv_text_retries_once_with_repair_prompt(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
### Motivation
- Avoid failing or rendering `Not specified` placeholders when the source CV omits certain sections (for example `hobby`), so anonymization should allow omitted or empty sections instead of requiring non-empty lists.

### Description
- Relaxed the anonymization prompts so Ollama is instructed to "omit that field or return an empty array" when the source CV has no content for a section and adjusted the repair prompt accordingly.
- Removed the strict `required` constraint from the `OLLAMA_JSON_FORMAT` and changed validation to reject only unexpected sections while allowing missing or empty known sections.
- Strip legacy `"Not specified"` placeholders during validation and skip empty sections when formatting the anonymized CV text so absent sections are not rendered.
- Added a small helper `_is_not_specified_value` and updated/added unit tests in `tests/unit/test_cv_export.py` to assert omitted/empty sections are handled and not rendered.

### Testing
- Ran `python -m compileall src` which completed successfully.
- Ran the test suite with `PYTHONPATH=src pytest -q` and observed all tests passing (`86 passed, 2 warnings`).
- Updated unit tests covering anonymization formatting and repair-path behavior which passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b85c7cf708328b808b69b890ccf53)