### PR TITLE
fix: pin bcrypt for passlib compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
   "python-multipart>=0.0.9,<1",
   "starlette>=0.37.0,<2",
   "uvicorn[standard]>=0.30.0,<1",
+  # passlib 1.7.x reads bcrypt.__about__.__version__, which was removed in bcrypt 4.1+.
+  "bcrypt>=4.0.1,<4.1",
   "pypdf>=4.0.0,<7",
   "reportlab>=4.0.0,<5",
 ]


### PR DESCRIPTION
### Motivation
- Vercel deployments can raise `AttributeError: module 'bcrypt' has no attribute '__about__'` because `passlib` 1.7.x expects `bcrypt.__about__.__version__`, which was removed in `bcrypt` 4.1+, so the dependency must be constrained to a compatible `bcrypt` release.

### Description
- Added an explicit `bcrypt` pin to `pyproject.toml` (`"bcrypt>=4.0.1,<4.1"`) with an inline comment explaining the compatibility reason.

### Testing
- Ran `python -m compileall src` and `pytest`, which completed successfully (`78 passed, 2 warnings`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58989d70288328b56737ffacd0f683)